### PR TITLE
Add RunJoinTest()

### DIFF
--- a/src/include/benchmark/sdbench/sdbench_configuration.h
+++ b/src/include/benchmark/sdbench/sdbench_configuration.h
@@ -36,8 +36,9 @@ enum OperatorType {
 enum ExperimentType {
   EXPERIMENT_TYPE_INVALID = 0,
 
-  EXPERIMENT_TYPE_ADAPT = 1
+  EXPERIMENT_TYPE_ADAPT = 1,
 
+  EXPERIMENT_TYPE_QUERY = 2,
 };
 
 extern int orig_scale_factor;

--- a/src/include/benchmark/sdbench/sdbench_configuration.h
+++ b/src/include/benchmark/sdbench/sdbench_configuration.h
@@ -29,8 +29,8 @@ enum OperatorType {
   OPERATOR_TYPE_INVALID = 0, /* invalid */
 
   OPERATOR_TYPE_DIRECT = 1,
-  OPERATOR_TYPE_INSERT = 2
-
+  OPERATOR_TYPE_INSERT = 2,
+  OPERATOR_TYPE_JOIN   = 3,
 };
 
 enum ExperimentType {

--- a/src/include/benchmark/sdbench/sdbench_workload.h
+++ b/src/include/benchmark/sdbench/sdbench_workload.h
@@ -28,6 +28,8 @@ void RunQuery(const std::vector<oid_t>& tuple_key_attrs,
 
 void RunInsertTest();
 
+void RunJoinTest();
+
 void RunAdaptExperiment();
 
 }  // namespace sdbench

--- a/src/include/benchmark/sdbench/sdbench_workload.h
+++ b/src/include/benchmark/sdbench/sdbench_workload.h
@@ -37,6 +37,8 @@ void RunJoinTest(const std::vector<oid_t> &left_table_tuple_key_attrs,
 
 void RunAdaptExperiment();
 
+void RunQueryExperiment();
+
 }  // namespace sdbench
 }  // namespace benchmark
 }  // namespace peloton

--- a/src/include/benchmark/sdbench/sdbench_workload.h
+++ b/src/include/benchmark/sdbench/sdbench_workload.h
@@ -28,7 +28,12 @@ void RunQuery(const std::vector<oid_t>& tuple_key_attrs,
 
 void RunInsertTest();
 
-void RunJoinTest();
+void RunJoinTest(const std::vector<oid_t> &left_table_tuple_key_attrs,
+                 const std::vector<oid_t> &left_table_index_key_attrs,
+                 const std::vector<oid_t> &right_table_tuple_key_attrs,
+                 const std::vector<oid_t> &right_table_index_key_attrs,
+                 const oid_t left_table_join_column,
+                 const oid_t right_table_join_column);
 
 void RunAdaptExperiment();
 

--- a/src/main/sdbench/sdbench.cpp
+++ b/src/main/sdbench/sdbench.cpp
@@ -10,7 +10,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-
 #include <iostream>
 #include <fstream>
 
@@ -51,6 +50,19 @@ void RunBenchmark() {
         RunInsertTest();
         break;
 
+      case OPERATOR_TYPE_JOIN: {
+        std::vector<oid_t> left_table_tuple_key_attrs = {1, 2};
+        std::vector<oid_t> left_table_index_key_attrs = {0, 1};
+        std::vector<oid_t> right_table_tuple_key_attrs = {4, 5};
+        std::vector<oid_t> right_table_index_key_attrs = {0, 1};
+        oid_t left_table_join_column = 3;
+        oid_t right_table_join_column = 6;
+        RunJoinTest(left_table_tuple_key_attrs, left_table_index_key_attrs,
+                    right_table_tuple_key_attrs, right_table_index_key_attrs,
+                    left_table_join_column, right_table_join_column);
+        break;
+      }
+
       default:
         LOG_ERROR("Unsupported test type : %d", state.operator_type);
         break;
@@ -60,7 +72,6 @@ void RunBenchmark() {
   // Experiment
   else {
     switch (state.experiment_type) {
-
       case EXPERIMENT_TYPE_ADAPT:
         RunAdaptExperiment();
         break;

--- a/src/main/sdbench/sdbench.cpp
+++ b/src/main/sdbench/sdbench.cpp
@@ -76,6 +76,10 @@ void RunBenchmark() {
         RunAdaptExperiment();
         break;
 
+      case EXPERIMENT_TYPE_QUERY:
+        RunQueryExperiment();
+        break;
+
       default:
         LOG_ERROR("Unsupported experiment_type : %d", state.experiment_type);
         break;

--- a/src/main/sdbench/sdbench_configuration.cpp
+++ b/src/main/sdbench/sdbench_configuration.cpp
@@ -82,6 +82,9 @@ static void ValidateOperator(const configuration &state) {
       case OPERATOR_TYPE_INSERT:
         LOG_INFO("%s : INSERT", "operator_type ");
         break;
+      case OPERATOR_TYPE_JOIN:
+        LOG_INFO("%s : JOIN", "operator_type ");
+        break;
       default:
         break;
     }

--- a/src/main/sdbench/sdbench_configuration.cpp
+++ b/src/main/sdbench/sdbench_configuration.cpp
@@ -161,7 +161,7 @@ static void ValidateSelectivity(const configuration &state) {
 }
 
 static void ValidateExperiment(const configuration &state) {
-  if (state.experiment_type <= 0 || state.experiment_type > 1) {
+  if (state.experiment_type <= 0 || state.experiment_type > 2) {
     LOG_ERROR("Invalid experiment_type :: %d", state.experiment_type);
     exit(EXIT_FAILURE);
   }

--- a/src/main/sdbench/sdbench_workload.cpp
+++ b/src/main/sdbench/sdbench_workload.cpp
@@ -194,7 +194,9 @@ void CreateIndexScanPredicate(std::vector<oid_t> key_attrs,
 /**
  * @brief Create a hybrid scan executor based on selected key columns.
  * @param tuple_key_attrs The columns which the seq scan predicate is on.
- * @param index_key_attrs ???
+ * @param index_key_attrs The columns in the *index key tuple* which the index
+ * scan predicate is on. It should match the corresponding columns in
+ * \b tuple_key_columns.
  * @param column_ids Column ids to added to the result tile after scan.
  * @return A hybrid scan executor based on the key columns.
  */
@@ -689,7 +691,6 @@ void RunJoinTest(const std::vector<oid_t> &left_table_tuple_key_attrs,
   auto join_type = JOIN_TYPE_INNER;
 
   // Create join predicate
-  // TODO: Generate predicate based on projectivity
   std::unique_ptr<expression::TupleValueExpression> left_table_attr(
       new expression::TupleValueExpression(VALUE_TYPE_INTEGER, 0,
                                            left_table_join_column));
@@ -699,7 +700,7 @@ void RunJoinTest(const std::vector<oid_t> &left_table_tuple_key_attrs,
 
   std::unique_ptr<expression::ComparisonExpression<expression::CmpLt>>
       join_predicate(new expression::ComparisonExpression<expression::CmpLt>(
-          EXPRESSION_TYPE_COMPARE_EQUAL, left_table_attr.get(),
+          EXPRESSION_TYPE_COMPARE_LESSTHAN, left_table_attr.get(),
           right_table_attr.get()));
 
   std::unique_ptr<const planner::ProjectInfo> project_info(nullptr);

--- a/src/main/sdbench/sdbench_workload.cpp
+++ b/src/main/sdbench/sdbench_workload.cpp
@@ -10,7 +10,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-
 #include <memory>
 #include <string>
 #include <unordered_map>
@@ -80,7 +79,7 @@ namespace benchmark {
 namespace sdbench {
 
 // Function definitions
-std::shared_ptr<index::Index> PickIndex(storage::DataTable* table,
+std::shared_ptr<index::Index> PickIndex(storage::DataTable *table,
                                         std::vector<oid_t> query_attrs);
 
 // Tuple id counter
@@ -107,16 +106,13 @@ static int GetUpperBound() {
   return upper_bound;
 }
 
-expression::AbstractExpression *CreateSimpleScanPredicate(oid_t key_attr,
-                                                          ExpressionType expression_type,
-                                                          oid_t constant){
-
+expression::AbstractExpression *CreateSimpleScanPredicate(
+    oid_t key_attr, ExpressionType expression_type, oid_t constant) {
   // First, create tuple value expression.
   oid_t left_tuple_idx = 0;
   expression::AbstractExpression *tuple_value_expr_left =
       expression::ExpressionUtil::TupleValueFactory(VALUE_TYPE_INTEGER,
-                                                    left_tuple_idx,
-                                                    key_attr);
+                                                    left_tuple_idx, key_attr);
 
   // Second, create constant value expression.
   Value constant_value_left = ValueFactory::GetIntegerValue(constant);
@@ -127,9 +123,7 @@ expression::AbstractExpression *CreateSimpleScanPredicate(oid_t key_attr,
   // Finally, link them together using an greater than expression.
   expression::AbstractExpression *predicate =
       expression::ExpressionUtil::ComparisonFactory(
-          expression_type,
-          tuple_value_expr_left,
-          constant_value_expr_left);
+          expression_type, tuple_value_expr_left, constant_value_expr_left);
 
   return predicate;
 }
@@ -139,8 +133,8 @@ expression::AbstractExpression *CreateSimpleScanPredicate(oid_t key_attr,
  * will be attr >= LOWER_BOUND AND attr < UPPER_BOUND.
  * LOWER_BOUND and UPPER_BOUND are determined by the selectivity config.
  */
-expression::AbstractExpression *CreateScanPredicate(std::vector<oid_t> key_attrs) {
-
+expression::AbstractExpression *CreateScanPredicate(
+    std::vector<oid_t> key_attrs) {
   const int tuple_start_offset = GetLowerBound();
   const int tuple_end_offset = GetUpperBound();
 
@@ -150,57 +144,50 @@ expression::AbstractExpression *CreateScanPredicate(std::vector<oid_t> key_attrs
   expression::AbstractExpression *predicate = nullptr;
 
   // Go over all key_attrs
-  for(auto key_attr : key_attrs) {
-
+  for (auto key_attr : key_attrs) {
     // ATTR >= LOWER_BOUND && < UPPER_BOUND
 
-    auto left_predicate = CreateSimpleScanPredicate(key_attr,
-                                                    EXPRESSION_TYPE_COMPARE_GREATERTHANOREQUALTO,
-                                                    tuple_start_offset);
+    auto left_predicate = CreateSimpleScanPredicate(
+        key_attr, EXPRESSION_TYPE_COMPARE_GREATERTHANOREQUALTO,
+        tuple_start_offset);
 
-    auto right_predicate = CreateSimpleScanPredicate(key_attr,
-                                                     EXPRESSION_TYPE_COMPARE_LESSTHAN,
-                                                     tuple_end_offset);
+    auto right_predicate = CreateSimpleScanPredicate(
+        key_attr, EXPRESSION_TYPE_COMPARE_LESSTHAN, tuple_end_offset);
 
     expression::AbstractExpression *attr_predicate =
-        expression::ExpressionUtil::ConjunctionFactory(EXPRESSION_TYPE_CONJUNCTION_AND,
-                                                       left_predicate,
-                                                       right_predicate);
+        expression::ExpressionUtil::ConjunctionFactory(
+            EXPRESSION_TYPE_CONJUNCTION_AND, left_predicate, right_predicate);
 
     // Build complex predicate
-    if(predicate == nullptr){
+    if (predicate == nullptr) {
       predicate = attr_predicate;
-    }
-    else {
+    } else {
       // Join predicate with given attribute predicate
-      predicate =  expression::ExpressionUtil::ConjunctionFactory(EXPRESSION_TYPE_CONJUNCTION_AND,
-                                                                  predicate,
-                                                                  attr_predicate);
+      predicate = expression::ExpressionUtil::ConjunctionFactory(
+          EXPRESSION_TYPE_CONJUNCTION_AND, predicate, attr_predicate);
     }
-
   }
 
   return predicate;
 }
 
 void CreateIndexScanPredicate(std::vector<oid_t> key_attrs,
-                              std::vector<oid_t>& key_column_ids,
-                              std::vector<ExpressionType>& expr_types,
-                              std::vector<Value>& values) {
+                              std::vector<oid_t> &key_column_ids,
+                              std::vector<ExpressionType> &expr_types,
+                              std::vector<Value> &values) {
   const int tuple_start_offset = GetLowerBound();
   const int tuple_end_offset = GetUpperBound();
 
   // Go over all key_attrs
-  for(auto key_attr : key_attrs) {
-
+  for (auto key_attr : key_attrs) {
     key_column_ids.push_back(key_attr);
-    expr_types.push_back(ExpressionType::EXPRESSION_TYPE_COMPARE_GREATERTHANOREQUALTO);
+    expr_types.push_back(
+        ExpressionType::EXPRESSION_TYPE_COMPARE_GREATERTHANOREQUALTO);
     values.push_back(ValueFactory::GetIntegerValue(tuple_start_offset));
 
     key_column_ids.push_back(key_attr);
     expr_types.push_back(ExpressionType::EXPRESSION_TYPE_COMPARE_LESSTHAN);
     values.push_back(ValueFactory::GetIntegerValue(tuple_end_offset));
-
   }
 }
 
@@ -212,9 +199,9 @@ void CreateIndexScanPredicate(std::vector<oid_t> key_attrs,
  * @return A hybrid scan executor based on the key columns.
  */
 std::shared_ptr<planner::HybridScanPlan> CreateHybridScanPlan(
-  const std::vector<oid_t>& tuple_key_attrs,
-  const std::vector<oid_t>& index_key_attrs,
-  const std::vector<oid_t>& column_ids) {
+    const std::vector<oid_t> &tuple_key_attrs,
+    const std::vector<oid_t> &index_key_attrs,
+    const std::vector<oid_t> &column_ids) {
   // Create and set up seq scan executor
   auto predicate = CreateScanPredicate(tuple_key_attrs);
 
@@ -235,23 +222,17 @@ std::shared_ptr<planner::HybridScanPlan> CreateHybridScanPlan(
   auto index = PickIndex(sdbench_table.get(), tuple_key_attrs);
 
   if (index != nullptr) {
-    index_scan_desc = planner::IndexScanPlan::IndexScanDesc(index,
-                                                            key_column_ids,
-                                                            expr_types,
-                                                            values,
-                                                            runtime_keys);
+    index_scan_desc = planner::IndexScanPlan::IndexScanDesc(
+        index, key_column_ids, expr_types, values, runtime_keys);
 
     hybrid_scan_type = HYBRID_SCAN_TYPE_HYBRID;
   }
 
   LOG_INFO("Hybrid scan type : %d", hybrid_scan_type);
 
-  std::shared_ptr<planner::HybridScanPlan> hybrid_scan_node(new planner::HybridScanPlan(
-                                           sdbench_table.get(),
-                                           predicate,
-                                           column_ids,
-                                           index_scan_desc,
-                                           hybrid_scan_type));
+  std::shared_ptr<planner::HybridScanPlan> hybrid_scan_node(
+      new planner::HybridScanPlan(sdbench_table.get(), predicate, column_ids,
+                                  index_scan_desc, hybrid_scan_type));
 
   return hybrid_scan_node;
 }
@@ -267,17 +248,10 @@ UNUSED_ATTRIBUTE static void WriteOutput(double duration) {
   duration *= 1000;
 
   LOG_INFO("----------------------------------------------------------");
-  LOG_INFO("%d %d %.3lf %.3lf %u %.1lf %d %d %d :: %.1lf ms",
-           state.layout_mode,
-           state.operator_type,
-           state.selectivity,
-           state.projectivity,
-           query_itr,
-           state.write_ratio,
-           state.scale_factor,
-           state.column_count,
-           state.tuples_per_tilegroup,
-           duration);
+  LOG_INFO("%d %d %.3lf %.3lf %u %.1lf %d %d %d :: %.1lf ms", state.layout_mode,
+           state.operator_type, state.selectivity, state.projectivity,
+           query_itr, state.write_ratio, state.scale_factor, state.column_count,
+           state.tuples_per_tilegroup, duration);
 
   out << state.layout_mode << " ";
   out << state.operator_type << " ";
@@ -341,14 +315,12 @@ static void ExecuteTest(std::vector<executor::AbstractExecutor *> &executors,
     for (auto &index_columns : index_columns_accessed) {
       brain::Sample index_sample(index_columns,
                                  duration / index_columns_accessed.size(),
-                                 sample_type,
-                                 selectivity);
+                                 sample_type, selectivity);
 
       // Record sample
       sdbench_table->RecordIndexSample(index_sample);
     }
   }
-
 }
 
 std::vector<double> GetColumnsAccessed(const std::vector<oid_t> &column_ids) {
@@ -370,9 +342,8 @@ std::vector<double> GetColumnsAccessed(const std::vector<oid_t> &column_ids) {
   return columns_accessed;
 }
 
-std::shared_ptr<index::Index> PickIndex(storage::DataTable* table,
+std::shared_ptr<index::Index> PickIndex(storage::DataTable *table,
                                         std::vector<oid_t> query_attrs) {
-
   // Construct set
   std::set<oid_t> query_attrs_set(query_attrs.begin(), query_attrs.end());
 
@@ -381,7 +352,7 @@ std::shared_ptr<index::Index> PickIndex(storage::DataTable* table,
   // Go over all indices
   bool query_index_found = false;
   oid_t index_itr = 0;
-  for(index_itr = 0; index_itr < index_count; index_itr++){
+  for (index_itr = 0; index_itr < index_count; index_itr++) {
     auto index_attrs = table->GetIndexAttrs(index_itr);
 
     auto index = table->GetIndex(index_itr);
@@ -389,19 +360,19 @@ std::shared_ptr<index::Index> PickIndex(storage::DataTable* table,
     LOG_INFO("Available Index :: %s", index_metadata->GetInfo().c_str());
 
     // Some attribute did not match
-    if(index_attrs != query_attrs_set) {
+    if (index_attrs != query_attrs_set) {
       continue;
     }
 
     // Fully constructed or not ?
-    if(state.only_use_full_indexes == true) {
+    if (state.only_use_full_indexes == true) {
       auto indexed_tg_count = index->GetIndexedTileGroupOffset();
       auto table_tg_count = table->GetTileGroupCount();
 
       LOG_INFO("Indexed TG Count : %lu", indexed_tg_count);
       LOG_INFO("Table TG Count : %lu", table_tg_count);
 
-      if(indexed_tg_count < table_tg_count){
+      if (indexed_tg_count < table_tg_count) {
         continue;
       }
     }
@@ -417,11 +388,10 @@ std::shared_ptr<index::Index> PickIndex(storage::DataTable* table,
   std::shared_ptr<index::Index> index;
 
   // Found index
-  if(query_index_found == true) {
+  if (query_index_found == true) {
     LOG_INFO("Found available Index");
     index = table->GetIndex(index_itr);
-  }
-  else {
+  } else {
     LOG_INFO("Did not find available index");
   }
 
@@ -429,33 +399,29 @@ std::shared_ptr<index::Index> PickIndex(storage::DataTable* table,
 }
 
 void RunSimpleQuery() {
-
   std::vector<oid_t> tuple_key_attrs;
   std::vector<oid_t> index_key_attrs;
 
   auto rand_sample = rand() % 10;
-  if(rand_sample <= 3) {
+  if (rand_sample <= 3) {
     tuple_key_attrs = {4};
     index_key_attrs = {0};
-  }
-  else if(rand_sample <= 6){
+  } else if (rand_sample <= 6) {
     tuple_key_attrs = {3};
     index_key_attrs = {0};
-  }
-  else {
+  } else {
     tuple_key_attrs = {2};
     index_key_attrs = {0};
   }
 
   UNUSED_ATTRIBUTE std::stringstream os;
   os << "Direct :: ";
-  for(auto tuple_key_attr : tuple_key_attrs){
+  for (auto tuple_key_attr : tuple_key_attrs) {
     os << tuple_key_attr << " ";
   }
   LOG_INFO("%s", os.str().c_str());
 
   RunQuery(tuple_key_attrs, index_key_attrs);
-
 }
 
 void RunModerateQuery() {
@@ -466,15 +432,13 @@ void RunModerateQuery() {
 
   auto rand_sample = rand() % 10;
 
-  if(rand_sample <= 3) {
+  if (rand_sample <= 3) {
     tuple_key_attrs = {3, 4};
     index_key_attrs = {0, 1};
-  }
-  else if(rand_sample <= 6){
+  } else if (rand_sample <= 6) {
     tuple_key_attrs = {3, 6};
     index_key_attrs = {0, 1};
-  }
-  else {
+  } else {
     tuple_key_attrs = {2};
     index_key_attrs = {0};
   }
@@ -482,8 +446,8 @@ void RunModerateQuery() {
   RunQuery(tuple_key_attrs, index_key_attrs);
 }
 
-void RunQuery(const std::vector<oid_t>& tuple_key_attrs,
-              const std::vector<oid_t>& index_key_attrs) {
+void RunQuery(const std::vector<oid_t> &tuple_key_attrs,
+              const std::vector<oid_t> &index_key_attrs) {
   const bool is_inlined = true;
   auto &txn_manager = concurrency::TransactionManagerFactory::GetInstance();
 
@@ -506,8 +470,10 @@ void RunQuery(const std::vector<oid_t>& tuple_key_attrs,
   std::unique_ptr<executor::ExecutorContext> context(
       new executor::ExecutorContext(txn));
 
-  auto hybrid_scan_node = CreateHybridScanPlan(tuple_key_attrs, index_key_attrs, column_ids);
-  executor::HybridScanExecutor hybrid_scan_executor(hybrid_scan_node.get(), context.get());
+  auto hybrid_scan_node =
+      CreateHybridScanPlan(tuple_key_attrs, index_key_attrs, column_ids);
+  executor::HybridScanExecutor hybrid_scan_executor(hybrid_scan_node.get(),
+                                                    context.get());
 
   /////////////////////////////////////////////////////////
   // AGGREGATION
@@ -533,8 +499,7 @@ void RunQuery(const std::vector<oid_t>& tuple_key_attrs,
   }
 
   std::unique_ptr<const planner::ProjectInfo> proj_info(
-      new planner::ProjectInfo(TargetList(),
-                               std::move(direct_map_list)));
+      new planner::ProjectInfo(TargetList(), std::move(direct_map_list)));
 
   // 3) Set up aggregates
   std::vector<planner::AggregatePlan::AggTerm> agg_terms;
@@ -542,12 +507,14 @@ void RunQuery(const std::vector<oid_t>& tuple_key_attrs,
     planner::AggregatePlan::AggTerm max_column_agg(
         EXPRESSION_TYPE_AGGREGATE_MAX,
         expression::ExpressionUtil::TupleValueFactory(VALUE_TYPE_INTEGER, 0,
-                                                      column_id), false);
+                                                      column_id),
+        false);
     agg_terms.push_back(max_column_agg);
   }
 
   // 4) Set up predicate (empty)
-  std::unique_ptr<const expression::AbstractExpression> aggregate_predicate(nullptr);
+  std::unique_ptr<const expression::AbstractExpression> aggregate_predicate(
+      nullptr);
 
   // 5) Create output table schema
   auto data_table_schema = sdbench_table->GetSchema();
@@ -556,12 +523,14 @@ void RunQuery(const std::vector<oid_t>& tuple_key_attrs,
     columns.push_back(data_table_schema->GetColumn(column_id));
   }
 
-  std::shared_ptr<const catalog::Schema> output_table_schema(new catalog::Schema(columns));
+  std::shared_ptr<const catalog::Schema> output_table_schema(
+      new catalog::Schema(columns));
 
   // OK) Create the plan node
   planner::AggregatePlan aggregation_node(
-      std::move(proj_info), std::move(aggregate_predicate), std::move(agg_terms),
-      std::move(group_by_columns), output_table_schema, AGGREGATE_TYPE_PLAIN);
+      std::move(proj_info), std::move(aggregate_predicate),
+      std::move(agg_terms), std::move(group_by_columns), output_table_schema,
+      AGGREGATE_TYPE_PLAIN);
 
   executor::AggregateExecutor aggregation_executor(&aggregation_node,
                                                    context.get());
@@ -578,10 +547,8 @@ void RunQuery(const std::vector<oid_t>& tuple_key_attrs,
   col_itr = 0;
   for (auto column_id : column_ids) {
     auto column =
-        catalog::Column(VALUE_TYPE_INTEGER,
-                        GetTypeSize(VALUE_TYPE_INTEGER),
-                        std::to_string(column_id),
-                        is_inlined);
+        catalog::Column(VALUE_TYPE_INTEGER, GetTypeSize(VALUE_TYPE_INTEGER),
+                        std::to_string(column_id), is_inlined);
     output_columns.push_back(column);
 
     old_to_new_cols[col_itr] = col_itr;
@@ -591,8 +558,7 @@ void RunQuery(const std::vector<oid_t>& tuple_key_attrs,
   std::shared_ptr<const catalog::Schema> output_schema(
       new catalog::Schema(output_columns));
   bool physify_flag = true;  // is going to create a physical tile
-  planner::MaterializationPlan mat_node(old_to_new_cols,
-                                        output_schema,
+  planner::MaterializationPlan mat_node(old_to_new_cols, output_schema,
                                         physify_flag);
 
   executor::MaterializationExecutor mat_executor(&mat_node, nullptr);
@@ -612,9 +578,7 @@ void RunQuery(const std::vector<oid_t>& tuple_key_attrs,
                                              tuple_key_attrs.end());
   auto selectivity = state.selectivity;
 
-  ExecuteTest(executors,
-              brain::SAMPLE_TYPE_ACCESS,
-              {index_columns_accessed},
+  ExecuteTest(executors, brain::SAMPLE_TYPE_ACCESS, {index_columns_accessed},
               selectivity);
 
   txn_manager.CommitTransaction();
@@ -656,11 +620,9 @@ void RunInsertTest() {
   auto bulk_insert_count = state.write_ratio * orig_tuple_count;
 
   LOG_INFO("Bulk insert count : %lf", bulk_insert_count);
-  planner::InsertPlan insert_node(sdbench_table.get(),
-                                  std::move(project_info),
+  planner::InsertPlan insert_node(sdbench_table.get(), std::move(project_info),
                                   bulk_insert_count);
-  executor::InsertExecutor insert_executor(&insert_node,
-                                           context.get());
+  executor::InsertExecutor insert_executor(&insert_node, context.get());
 
   /////////////////////////////////////////////////////////
   // EXECUTE
@@ -675,9 +637,7 @@ void RunInsertTest() {
   std::vector<double> index_columns_accessed;
   double selectivity = 0;
 
-  ExecuteTest(executors,
-              brain::SAMPLE_TYPE_UPDATE,
-              {index_columns_accessed},
+  ExecuteTest(executors, brain::SAMPLE_TYPE_UPDATE, {index_columns_accessed},
               selectivity);
 
   txn_manager.CommitTransaction();
@@ -712,12 +672,15 @@ void RunJoinTest(const std::vector<oid_t> &left_table_tuple_key_attrs,
   }
 
   // Create and set up seq scan executor
-  auto left_table_scan_node = CreateHybridScanPlan(left_table_tuple_key_attrs, left_table_index_key_attrs, column_ids);
-  auto right_table_scan_node = CreateHybridScanPlan(right_table_tuple_key_attrs, right_table_index_key_attrs, column_ids);
+  auto left_table_scan_node = CreateHybridScanPlan(
+      left_table_tuple_key_attrs, left_table_index_key_attrs, column_ids);
+  auto right_table_scan_node = CreateHybridScanPlan(
+      right_table_tuple_key_attrs, right_table_index_key_attrs, column_ids);
 
-  executor::HybridScanExecutor left_table_hybrid_scan_executor(left_table_scan_node.get(), context.get());
-  executor::HybridScanExecutor right_table_hybrid_scan_executor(right_table_scan_node.get(), context.get());
-
+  executor::HybridScanExecutor left_table_hybrid_scan_executor(
+      left_table_scan_node.get(), context.get());
+  executor::HybridScanExecutor right_table_hybrid_scan_executor(
+      right_table_scan_node.get(), context.get());
 
   /////////////////////////////////////////////////////////
   // JOIN EXECUTOR
@@ -728,13 +691,16 @@ void RunJoinTest(const std::vector<oid_t> &left_table_tuple_key_attrs,
   // Create join predicate
   // TODO: Generate predicate based on projectivity
   std::unique_ptr<expression::TupleValueExpression> left_table_attr(
-    new expression::TupleValueExpression(VALUE_TYPE_INTEGER, 0, left_table_join_column));
+      new expression::TupleValueExpression(VALUE_TYPE_INTEGER, 0,
+                                           left_table_join_column));
   std::unique_ptr<expression::TupleValueExpression> right_table_attr(
-    new expression::TupleValueExpression(VALUE_TYPE_INTEGER, 1, right_table_join_column));
+      new expression::TupleValueExpression(VALUE_TYPE_INTEGER, 1,
+                                           right_table_join_column));
 
-  std::unique_ptr<expression::ComparisonExpression<expression::CmpLt>> join_predicate(
-    new expression::ComparisonExpression<expression::CmpLt>(
-        EXPRESSION_TYPE_COMPARE_EQUAL, left_table_attr.get(), right_table_attr.get()));
+  std::unique_ptr<expression::ComparisonExpression<expression::CmpLt>>
+      join_predicate(new expression::ComparisonExpression<expression::CmpLt>(
+          EXPRESSION_TYPE_COMPARE_EQUAL, left_table_attr.get(),
+          right_table_attr.get()));
 
   std::unique_ptr<const planner::ProjectInfo> project_info(nullptr);
   std::shared_ptr<const catalog::Schema> schema(nullptr);
@@ -770,8 +736,8 @@ void RunJoinTest(const std::vector<oid_t> &left_table_tuple_key_attrs,
   std::shared_ptr<const catalog::Schema> output_schema(
       new catalog::Schema(output_columns));
   bool physify_flag = true;  // is going to create a physical tile
-  planner::MaterializationPlan mat_node(old_to_new_cols,
-                                        output_schema, physify_flag);
+  planner::MaterializationPlan mat_node(old_to_new_cols, output_schema,
+                                        physify_flag);
 
   executor::MaterializationExecutor mat_executor(&mat_node, nullptr);
   mat_executor.AddChild(&nested_loop_join_executor);
@@ -787,17 +753,17 @@ void RunJoinTest(const std::vector<oid_t> &left_table_tuple_key_attrs,
   // COLLECT STATS
   /////////////////////////////////////////////////////////
 
-  std::vector<double> left_table_index_columns_accessed(left_table_tuple_key_attrs.begin(),
-    left_table_tuple_key_attrs.end());
-  std::vector<double> right_table_index_columns_accessed(right_table_tuple_key_attrs.begin(),
-    right_table_tuple_key_attrs.end());
+  std::vector<double> left_table_index_columns_accessed(
+      left_table_tuple_key_attrs.begin(), left_table_tuple_key_attrs.end());
+  std::vector<double> right_table_index_columns_accessed(
+      right_table_tuple_key_attrs.begin(), right_table_tuple_key_attrs.end());
 
   auto selectivity = state.selectivity;
 
-  ExecuteTest(executors,
-    brain::SAMPLE_TYPE_ACCESS,
-    {left_table_index_columns_accessed, right_table_index_columns_accessed},
-    selectivity);
+  ExecuteTest(
+      executors, brain::SAMPLE_TYPE_ACCESS,
+      {left_table_index_columns_accessed, right_table_index_columns_accessed},
+      selectivity);
 
   txn_manager.CommitTransaction();
 }
@@ -812,7 +778,7 @@ static void RunAdaptTest() {
 
   state.operator_type = OPERATOR_TYPE_DIRECT;
 
-  for(oid_t repeat_itr = 0; repeat_itr < repeat_count; repeat_itr++) {
+  for (oid_t repeat_itr = 0; repeat_itr < repeat_count; repeat_itr++) {
     if (rand_sample < write_ratio) {
       // Do insert
       LOG_INFO("Do insert");
@@ -825,15 +791,13 @@ static void RunAdaptTest() {
   }
 
   LOG_INFO("Total Duration : %.2lf", total_duration);
-
 }
 
 std::vector<std::size_t> phase_lengths = {40};
 
 void RunAdaptExperiment() {
-
   // Setup layout tuner
-  auto& index_tuner = brain::IndexTuner::GetInstance();
+  auto &index_tuner = brain::IndexTuner::GetInstance();
   std::thread index_builder;
 
   state.projectivity = 1.0;
@@ -851,7 +815,7 @@ void RunAdaptExperiment() {
 
   CreateAndLoadTable((LayoutType)peloton_layout_mode);
 
-  for(auto phase_length : phase_lengths) {
+  for (auto phase_length : phase_lengths) {
     // Set phase length
     state.phase_length = phase_length;
     LOG_INFO("Phase Length: %lu", state.phase_length);
@@ -872,7 +836,6 @@ void RunAdaptExperiment() {
 
     // Drop Indexes
     DropIndexes();
-
   }
 
   // Reset
@@ -881,7 +844,6 @@ void RunAdaptExperiment() {
 
   out.close();
 }
-
 
 }  // namespace sdbench
 }  // namespace benchmark


### PR DESCRIPTION
* Not very sure about the semantic of `index_key_attrs` and `tuple_key_attrs`.
* Currently not using `projectivity` for join, now the predicate is like A.x = B.y, x and y is given by the input parameter. In the future will implement A.attr{i in I} = B.attr{j in J}, where I and J are two equal length lists which specify the attrs used in two tables for equal join. The length of I and J will be calculated like `COLUMN_COUNT * state.projectivity`