### PR TITLE
Fix the benchmark for query test

### DIFF
--- a/src/brain/index_tuner.cpp
+++ b/src/brain/index_tuner.cpp
@@ -52,7 +52,7 @@ void IndexTuner::Start(){
 // Add an ad-hoc index
 static void AddIndex(storage::DataTable* table,
                      std::set<oid_t> suggested_index_attrs) {
-
+  LOG_INFO("Add an index");
   // Construct index metadata
   std::vector<oid_t> key_attrs(suggested_index_attrs.size());
   std::copy(suggested_index_attrs.begin(),

--- a/src/brain/index_tuner.cpp
+++ b/src/brain/index_tuner.cpp
@@ -52,7 +52,6 @@ void IndexTuner::Start(){
 // Add an ad-hoc index
 static void AddIndex(storage::DataTable* table,
                      std::set<oid_t> suggested_index_attrs) {
-  LOG_INFO("Add an index");
   // Construct index metadata
   std::vector<oid_t> key_attrs(suggested_index_attrs.size());
   std::copy(suggested_index_attrs.begin(),

--- a/src/executor/nested_loop_join_executor.cpp
+++ b/src/executor/nested_loop_join_executor.cpp
@@ -60,10 +60,6 @@ bool NestedLoopJoinExecutor::DInit() {
   left_matching_idx = 0;
   right_matching_idx = 0;
 
-  // init the left and right child
-  children_[0]->Init();
-  children_[1]->Init();
-
   return true;
 }
 

--- a/src/executor/nested_loop_join_executor.cpp
+++ b/src/executor/nested_loop_join_executor.cpp
@@ -44,11 +44,25 @@ bool NestedLoopJoinExecutor::DInit() {
     return status;
   }
 
-  PL_ASSERT(right_result_tiles_.empty());
-  right_child_done_ = false;
-  right_result_itr_ = 0;
+  // WARNING: hard code the logic to reset the state of the executor for sdbench
+  result.clear();
+  left_result_tiles_.clear();
+  right_result_tiles_.clear();
 
-  PL_ASSERT(left_result_tiles_.empty());
+  right_child_done_ = false;
+  left_child_done_ = false;
+  right_result_itr_ = 0;
+  left_result_itr_ = 0;
+
+  no_matching_left_row_sets_.clear();
+  no_matching_right_row_sets_.clear();
+
+  left_matching_idx = 0;
+  right_matching_idx = 0;
+
+  // init the left and right child
+  children_[0]->Init();
+  children_[1]->Init();
 
   return true;
 }

--- a/src/include/benchmark/sdbench/sdbench_configuration.h
+++ b/src/include/benchmark/sdbench/sdbench_configuration.h
@@ -81,10 +81,6 @@ class configuration {
 
   // Adapt the indexes ?
   bool adapt_indexes;
-
-  // scan type
-  HybridScanType hybrid_scan_type;
-
 };
 
 void Usage(FILE *out);

--- a/src/main/sdbench/sdbench_configuration.cpp
+++ b/src/main/sdbench/sdbench_configuration.cpp
@@ -210,7 +210,7 @@ void ParseArguments(int argc, char *argv[], configuration &state) {
   state.query_complexity_type = QUERY_COMPLEXITY_TYPE_SIMPLE;
 
   state.scale_factor = 100.0;
-  state.attribute_count = 10;
+  state.attribute_count = 20;
 
   state.write_ratio = 0.0;
   state.tuples_per_tilegroup = DEFAULT_TUPLES_PER_TILEGROUP;

--- a/src/main/sdbench/sdbench_configuration.cpp
+++ b/src/main/sdbench/sdbench_configuration.cpp
@@ -31,7 +31,6 @@ void Usage() {
       "   -a --attribute_count       :  # of attributes\n"
       "   -w --write_ratio           :  Fraction of writes\n"
       "   -g --tuples_per_tg         :  # of tuples per tilegroup\n"
-      "   -y --hybrid_scan_type      :  Hybrid scan type\n"
       "   -t --phase_length          :  Length of a phase\n"
       "   -q --total_ops             :  Total # of ops\n"
       "   -s --selectivity           :  Selectivity\n"
@@ -48,7 +47,6 @@ static struct option opts[] = {
     {"attribute_count", optional_argument, NULL, 'a'},
     {"write_ratio", optional_argument, NULL, 'w'},
     {"tuples_per_tg", optional_argument, NULL, 'g'},
-    {"hybrid_scan_type", optional_argument, NULL, 'y'},
     {"phase_length", optional_argument, NULL, 't'},
     {"total_ops", optional_argument, NULL, 'q'},
     {"selectivity", optional_argument, NULL, 's'},
@@ -110,27 +108,6 @@ static void ValidateQueryComplexityType(const configuration &state) {
           break;
       }
     }
-}
-
-static void ValidateHybridScanType(const configuration &state) {
-  if (state.hybrid_scan_type < 1 || state.hybrid_scan_type > 3) {
-    LOG_ERROR("Invalid hybrid_scan_type :: %d", state.hybrid_scan_type);
-    exit(EXIT_FAILURE);
-  } else {
-    switch (state.hybrid_scan_type) {
-      case HYBRID_SCAN_TYPE_SEQUENTIAL:
-        LOG_INFO("%s : SEQUENTIAL", "hybrid_scan_type ");
-        break;
-      case HYBRID_SCAN_TYPE_INDEX:
-        LOG_INFO("%s : INDEX", "hybrid_scan_type ");
-        break;
-      case HYBRID_SCAN_TYPE_HYBRID:
-        LOG_INFO("%s : HYBRID", "hybrid_scan_type ");
-        break;
-      default:
-        break;
-    }
-  }
 }
 
 static void ValidateScaleFactor(const configuration &state) {
@@ -238,8 +215,6 @@ void ParseArguments(int argc, char *argv[], configuration &state) {
   state.write_ratio = 0.0;
   state.tuples_per_tilegroup = DEFAULT_TUPLES_PER_TILEGROUP;
 
-  state.hybrid_scan_type = HYBRID_SCAN_TYPE_HYBRID;
-
   state.total_ops = 1;
   state.phase_length = 1;
 
@@ -276,9 +251,6 @@ void ParseArguments(int argc, char *argv[], configuration &state) {
       case 'g':
         state.tuples_per_tilegroup = atoi(optarg);
         break;
-      case 'y':
-        state.hybrid_scan_type = (HybridScanType)atoi(optarg);
-        break;
       case 'q':
         state.total_ops = atol(optarg);
         break;
@@ -309,7 +281,6 @@ void ParseArguments(int argc, char *argv[], configuration &state) {
   ValidateQueryComplexityType(state);
   ValidateScaleFactor(state);
   ValidateAttributeCount(state);
-  ValidateHybridScanType(state);
   ValidateWriteRatio(state);
   ValidateTuplesPerTileGroup(state);
   ValidateTotalOps(state);

--- a/src/main/sdbench/sdbench_workload.cpp
+++ b/src/main/sdbench/sdbench_workload.cpp
@@ -233,7 +233,7 @@ static std::shared_ptr<planner::HybridScanPlan> CreateHybridScanPlan(
     hybrid_scan_type = HYBRID_SCAN_TYPE_HYBRID;
   }
 
-  LOG_TRACE("Hybrid scan type : %d", hybrid_scan_type);
+  LOG_INFO("Hybrid scan type : %d", hybrid_scan_type);
 
   std::shared_ptr<planner::HybridScanPlan> hybrid_scan_node(
       new planner::HybridScanPlan(sdbench_table.get(), predicate, column_ids,
@@ -320,7 +320,7 @@ static void ExecuteTest(std::vector<executor::AbstractExecutor *> &executors,
     auto duration = timer.GetDuration();
     total_duration += duration;
 
-    //WriteOutput(duration);
+    WriteOutput(duration);
 
     // Construct sample
     for (auto &index_columns : index_columns_accessed) {
@@ -597,7 +597,12 @@ static void RunComplexQuery() {
 }
 
 static void QueryHelper(const std::vector<oid_t> &tuple_key_attrs,
-                 const std::vector<oid_t> &index_key_attrs) {
+                        const std::vector<oid_t> &index_key_attrs) {
+  std::string key_attrs = "";
+  for (oid_t attr : tuple_key_attrs) {
+    key_attrs += " " + std::to_string(attr);
+  }
+  LOG_INFO("Run query on %s ", key_attrs.c_str());
   const bool is_inlined = true;
   auto &txn_manager = concurrency::TransactionManagerFactory::GetInstance();
 
@@ -756,6 +761,7 @@ static void RunQuery() {
 }
 
 static void RunInsert() {
+  LOG_INFO("Run Insert");
   auto &txn_manager = concurrency::TransactionManagerFactory::GetInstance();
 
   auto txn = txn_manager.BeginTransaction();
@@ -842,12 +848,10 @@ void RunSDBenchTest() {
 
     // Do insert
     if (rand_sample < write_ratio) {
-      LOG_INFO("Run insert");
       RunInsert();
     }
     // Do read
     else {
-      LOG_INFO("Run query");
       RunQuery();
     }
 


### PR DESCRIPTION
This PR fixes the problem of initializing the `nested_loop_join_executor` multiple times, the states of the executor is not fully reset. 

Right now we are caching the plan and executor in the same phase, I recommend that we do not cache, because during one phase an index could be constructed and the plan should be changed accordingly (from seq scan to hybrid scan). I have observed that for phase length = 40, the index tuner is able to begin to constructing a new index

@jarulraj 