### PR TITLE
inplace update + update workload

### DIFF
--- a/src/brain/index_tuner.cpp
+++ b/src/brain/index_tuner.cpp
@@ -493,6 +493,7 @@ oid_t IndexTuner::GetIndexCount() const {
 }
 
 void IndexTuner::Tune() {
+  LOG_INFO("Begin tuning");
   // Continue till signal is not false
   while (index_tuning_stop == false) {
     // Go over all tables

--- a/src/brain/index_tuner.cpp
+++ b/src/brain/index_tuner.cpp
@@ -10,11 +10,11 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include <unordered_map>
 #include <algorithm>
+#include <unordered_map>
 
-#include "brain/index_tuner.h"
 #include "brain/clusterer.h"
+#include "brain/index_tuner.h"
 
 #include "catalog/schema.h"
 #include "common/logger.h"
@@ -26,27 +26,25 @@
 namespace peloton {
 namespace brain {
 
-IndexTuner &IndexTuner::GetInstance() {
+IndexTuner& IndexTuner::GetInstance() {
   static IndexTuner index_tuner;
   return index_tuner;
 }
 
-IndexTuner::IndexTuner(){
+IndexTuner::IndexTuner() {
   // Nothing to do here !
 }
 
-IndexTuner::~IndexTuner(){
+IndexTuner::~IndexTuner() {
   // Nothing to do here !
 }
 
-void IndexTuner::Start(){
-
+void IndexTuner::Start() {
   // Set signal
   index_tuning_stop = false;
 
   // Launch thread
   index_tuner_thread = std::thread(&brain::IndexTuner::Tune, this);
-
 }
 
 // Add an ad-hoc index
@@ -54,16 +52,15 @@ static void AddIndex(storage::DataTable* table,
                      std::set<oid_t> suggested_index_attrs) {
   // Construct index metadata
   std::vector<oid_t> key_attrs(suggested_index_attrs.size());
-  std::copy(suggested_index_attrs.begin(),
-            suggested_index_attrs.end(),
+  std::copy(suggested_index_attrs.begin(), suggested_index_attrs.end(),
             key_attrs.begin());
 
   auto index_count = table->GetIndexCount();
   auto index_oid = index_count + 1;
 
   auto tuple_schema = table->GetSchema();
-  catalog::Schema *key_schema;
-  index::IndexMetadata *index_metadata;
+  catalog::Schema* key_schema;
+  index::IndexMetadata* index_metadata;
   bool unique;
 
   key_schema = catalog::Schema::CopySchema(tuple_schema, key_attrs);
@@ -72,14 +69,9 @@ static void AddIndex(storage::DataTable* table,
   unique = true;
 
   index_metadata = new index::IndexMetadata(
-      "adhoc_index_" + std::to_string(index_oid),
-      index_oid,
-      INDEX_TYPE_SKIPLIST,
-      INDEX_CONSTRAINT_TYPE_PRIMARY_KEY,
-      tuple_schema,
-      key_schema,
-      key_attrs,
-      unique);
+      "adhoc_index_" + std::to_string(index_oid), index_oid,
+      INDEX_TYPE_SKIPLIST, INDEX_CONSTRAINT_TYPE_PRIMARY_KEY, tuple_schema,
+      key_schema, key_attrs, unique);
 
   // Set initial utility ratio
   double intial_utility_ratio = 0.5;
@@ -92,12 +84,10 @@ static void AddIndex(storage::DataTable* table,
   table->AddIndex(adhoc_index);
 
   LOG_TRACE("Added suggested index : %s", index_metadata->GetInfo().c_str());
-
 }
 
-void IndexTuner::BuildIndex(storage::DataTable *table,
+void IndexTuner::BuildIndex(storage::DataTable* table,
                             std::shared_ptr<index::Index> index) {
-
   auto table_schema = table->GetSchema();
   auto index_tile_group_offset = index->GetIndexedTileGroupOffset();
   auto table_tile_group_count = table->GetTileGroupCount();
@@ -108,9 +98,9 @@ void IndexTuner::BuildIndex(storage::DataTable *table,
   std::unique_ptr<storage::Tuple> key(new storage::Tuple(index_schema, true));
 
   while (index_tile_group_offset < table_tile_group_count &&
-      (tile_groups_indexed < max_tile_groups_indexed)) {
-
-    std::unique_ptr<storage::Tuple> tuple_ptr(new storage::Tuple(table_schema, true));
+         (tile_groups_indexed < max_tile_groups_indexed)) {
+    std::unique_ptr<storage::Tuple> tuple_ptr(
+        new storage::Tuple(table_schema, true));
 
     auto tile_group = table->GetTileGroup(index_tile_group_offset);
     auto tile_group_id = tile_group->GetTileGroupId();
@@ -136,40 +126,34 @@ void IndexTuner::BuildIndex(storage::DataTable *table,
     index_tile_group_offset++;
     tile_groups_indexed++;
   }
-
 }
 
-void IndexTuner::BuildIndices(storage::DataTable *table) {
-
+void IndexTuner::BuildIndices(storage::DataTable* table) {
   oid_t index_count = table->GetIndexCount();
 
-  for(oid_t index_itr = 0; index_itr < index_count; index_itr++){
-
+  for (oid_t index_itr = 0; index_itr < index_count; index_itr++) {
     // Get index
     auto index = table->GetIndex(index_itr);
 
     // Build index
     BuildIndex(table, index);
   }
-
 }
 
-double IndexTuner::ComputeWorkloadWriteRatio(const std::vector<brain::Sample>& samples) {
-
+double IndexTuner::ComputeWorkloadWriteRatio(
+    const std::vector<brain::Sample>& samples) {
   double write_ratio = 0;
 
   double total_read_duration = 0;
   double total_write_duration = 0;
 
   // Go over all samples
-  for(auto sample : samples){
-    if(sample.sample_type_ == SAMPLE_TYPE_ACCESS){
+  for (auto sample : samples) {
+    if (sample.sample_type_ == SAMPLE_TYPE_ACCESS) {
       total_read_duration += sample.weight_;
-    }
-    else if(sample.sample_type_ == SAMPLE_TYPE_UPDATE){
+    } else if (sample.sample_type_ == SAMPLE_TYPE_UPDATE) {
       total_write_duration += sample.weight_;
-    }
-    else {
+    } else {
       throw Exception("Unknown sample type : " +
                       std::to_string(sample.sample_type_));
     }
@@ -181,12 +165,12 @@ double IndexTuner::ComputeWorkloadWriteRatio(const std::vector<brain::Sample>& s
   write_ratio = total_write_duration / (total_duration);
 
   // Compute exponential moving average
-  if(average_write_ratio == INVALID_RATIO) {
+  if (average_write_ratio == INVALID_RATIO) {
     average_write_ratio = write_ratio;
-  }
-  else {
+  } else {
     // S_t = alpha * Y_t + (1 - alpha) * S_t-1
-    average_write_ratio = write_ratio * alpha +  (1 - alpha) * average_write_ratio;
+    average_write_ratio =
+        write_ratio * alpha + (1 - alpha) * average_write_ratio;
   }
 
   LOG_TRACE("Average write Ratio : %.2lf", average_write_ratio);
@@ -198,28 +182,26 @@ double IndexTuner::ComputeWorkloadWriteRatio(const std::vector<brain::Sample>& s
 typedef std::pair<brain::Sample, double> sample_frequency_map_entry;
 
 bool SampleFrequencyMapEntryComparator(sample_frequency_map_entry a,
-                                       sample_frequency_map_entry b){
+                                       sample_frequency_map_entry b) {
   return a.second > b.second;
 }
 
-std::vector<sample_frequency_map_entry>
-GetFrequentSamples(const std::vector<brain::Sample>& samples){
-
+std::vector<sample_frequency_map_entry> GetFrequentSamples(
+    const std::vector<brain::Sample>& samples) {
   std::unordered_map<brain::Sample, double> sample_frequency_map;
   double total_metric = 0;
 
   // Go over all samples
-  for(auto sample : samples){
-    if(sample.sample_type_ == SAMPLE_TYPE_ACCESS){
+  for (auto sample : samples) {
+    if (sample.sample_type_ == SAMPLE_TYPE_ACCESS) {
       // Update sample count
       sample_frequency_map[sample] += sample.metric_;
       total_metric += sample.metric_;
-    }
-    else if(sample.sample_type_ == SAMPLE_TYPE_UPDATE){
+    } else if (sample.sample_type_ == SAMPLE_TYPE_UPDATE) {
       // Ignore update samples
-    }
-    else {
-      throw Exception("Unknown sample type : " + std::to_string(sample.sample_type_));
+    } else {
+      throw Exception("Unknown sample type : " +
+                      std::to_string(sample.sample_type_));
     }
   }
 
@@ -228,16 +210,16 @@ GetFrequentSamples(const std::vector<brain::Sample>& samples){
   // Normalize
   std::unordered_map<brain::Sample, double>::iterator sample_frequency_map_itr;
 
-  for(sample_frequency_map_itr = sample_frequency_map.begin();
-      sample_frequency_map_itr != sample_frequency_map.end();
-      ++sample_frequency_map_itr) {
+  for (sample_frequency_map_itr = sample_frequency_map.begin();
+       sample_frequency_map_itr != sample_frequency_map.end();
+       ++sample_frequency_map_itr) {
     // Normalize sample's utility
     sample_frequency_map_itr->second /= total_metric;
   }
 
   std::vector<sample_frequency_map_entry> sample_frequency_entry_list;
 
-  for(auto sample_frequency_map_entry : sample_frequency_map){
+  for (auto sample_frequency_map_entry : sample_frequency_map) {
     auto entry = std::make_pair(sample_frequency_map_entry.first,
                                 sample_frequency_map_entry.second);
     sample_frequency_entry_list.push_back(entry);
@@ -250,9 +232,8 @@ GetFrequentSamples(const std::vector<brain::Sample>& samples){
   return sample_frequency_entry_list;
 }
 
-std::vector<std::vector<double>>
-GetSuggestedIndices(const std::vector<sample_frequency_map_entry>& list){
-
+std::vector<std::vector<double>> GetSuggestedIndices(
+    const std::vector<sample_frequency_map_entry>& list) {
   // Find frequent samples
   size_t frequency_rank_threshold = 10;
 
@@ -260,9 +241,9 @@ GetSuggestedIndices(const std::vector<sample_frequency_map_entry>& list){
   std::vector<std::vector<double>> suggested_indices;
   auto list_size = list.size();
 
-  for(size_t entry_itr = 0;
-      (entry_itr < frequency_rank_threshold) && (entry_itr < list_size);
-      entry_itr++){
+  for (size_t entry_itr = 0;
+       (entry_itr < frequency_rank_threshold) && (entry_itr < list_size);
+       entry_itr++) {
     auto& entry = list[entry_itr];
     auto& sample = entry.first;
     LOG_TRACE("%s Utility : %.2lf", sample.GetInfo().c_str(), entry.second);
@@ -273,8 +254,7 @@ GetSuggestedIndices(const std::vector<sample_frequency_map_entry>& list){
   return suggested_indices;
 }
 
-size_t IndexTuner::CheckIndexStorageFootprint(storage::DataTable *table){
-
+size_t IndexTuner::CheckIndexStorageFootprint(storage::DataTable* table) {
   // Construct indices in suggested index list
   oid_t index_count = table->GetIndexCount();
   size_t min_tuple_count = 1024;
@@ -296,69 +276,62 @@ size_t IndexTuner::CheckIndexStorageFootprint(storage::DataTable *table){
   return max_allowed_indexes;
 }
 
-double GetCurrentIndexUtility(std::set<oid_t> suggested_index_set,
-                              const std::vector<sample_frequency_map_entry>& list){
-
+double GetCurrentIndexUtility(
+    std::set<oid_t> suggested_index_set,
+    const std::vector<sample_frequency_map_entry>& list) {
   double current_index_utility = 0;
   auto list_size = list.size();
 
-  for(size_t entry_itr = 0; entry_itr < list_size; entry_itr++){
+  for (size_t entry_itr = 0; entry_itr < list_size; entry_itr++) {
     auto& entry = list[entry_itr];
     auto& sample = entry.first;
     auto& columns = sample.columns_accessed_;
 
     std::set<oid_t> columns_set(columns.begin(), columns.end());
 
-    if(columns_set == suggested_index_set){
+    if (columns_set == suggested_index_set) {
       LOG_TRACE("Sample~Index Match : %s ", sample.GetInfo().c_str());
       current_index_utility = entry.second;
       break;
     }
-
   }
 
   return current_index_utility;
 }
 
-void IndexTuner::DropIndexes(storage::DataTable *table) {
-
+void IndexTuner::DropIndexes(storage::DataTable* table) {
   oid_t index_count = table->GetIndexCount();
 
   // Go over indices
   oid_t index_itr;
-  for(index_itr = 0; index_itr < index_count; index_itr++){
-
+  for (index_itr = 0; index_itr < index_count; index_itr++) {
     auto index = table->GetIndex(index_itr);
     auto index_metadata = index->GetMetadata();
     auto average_index_utility = index_metadata->GetUtility();
     UNUSED_ATTRIBUTE auto index_oid = index->GetOid();
 
     // Check if index utility below threshold and drop if needed
-    if(average_index_utility < index_utility_threshold) {
+    if (average_index_utility < index_utility_threshold) {
       LOG_TRACE("Dropping index : %s", index_metadata->GetInfo().c_str());
 
       // TODO: Uncomment this
-      //table->DropIndexWithOid(index_oid);
+      // table->DropIndexWithOid(index_oid);
 
       // Update index count
       index_count = table->GetIndexCount();
     }
-
   }
-
 }
 
-void AddIndexes(storage::DataTable *table,
+void AddIndexes(storage::DataTable* table,
                 const std::vector<std::vector<double>>& suggested_indices,
                 size_t max_allowed_indexes) {
-
   oid_t index_count = table->GetIndexCount();
   size_t constructed_index_itr = 0;
 
-  for(auto suggested_index : suggested_indices) {
-
+  for (auto suggested_index : suggested_indices) {
     // Check if we have storage space
-    if((max_allowed_indexes <= 0) ||
+    if ((max_allowed_indexes <= 0) ||
         (constructed_index_itr >= max_allowed_indexes)) {
       LOG_INFO("No more index space");
       break;
@@ -370,11 +343,10 @@ void AddIndexes(storage::DataTable *table,
     // Go over all indices
     bool suggested_index_found = false;
     oid_t index_itr;
-    for(index_itr = 0; index_itr < index_count; index_itr++){
-
+    for (index_itr = 0; index_itr < index_count; index_itr++) {
       // Check attributes
       auto index_attrs = table->GetIndexAttrs(index_itr);
-      if(index_attrs != suggested_index_set) {
+      if (index_attrs != suggested_index_set) {
         continue;
       }
 
@@ -384,39 +356,32 @@ void AddIndexes(storage::DataTable *table,
     }
 
     // Did we find suggested index ?
-    if(suggested_index_found == false) {
-
+    if (suggested_index_found == false) {
       LOG_TRACE("Did not find suggested index.");
 
       // Add adhoc index with given utility
       AddIndex(table, suggested_index_set);
       constructed_index_itr++;
-    }
-    else {
+    } else {
       LOG_TRACE("Found suggested index.");
     }
-
   }
 }
 
 void UpdateIndexUtility(storage::DataTable* table,
                         const std::vector<sample_frequency_map_entry>& list) {
-
   oid_t index_count = table->GetIndexCount();
 
-  for(oid_t index_itr = 0; index_itr < index_count; index_itr++){
-
+  for (oid_t index_itr = 0; index_itr < index_count; index_itr++) {
     // Get index
     auto index = table->GetIndex(index_itr);
     auto index_metadata = index->GetMetadata();
     auto index_key_attrs = index_metadata->GetKeyAttrs();
 
-    std::set<oid_t> index_set(index_key_attrs.begin(),
-                              index_key_attrs.end());
+    std::set<oid_t> index_set(index_key_attrs.begin(), index_key_attrs.end());
 
     // Get current index utility
-    auto current_index_utility = GetCurrentIndexUtility(index_set,
-                                                        list);
+    auto current_index_utility = GetCurrentIndexUtility(index_set, list);
 
     auto average_index_utility = index_metadata->GetUtility();
 
@@ -427,27 +392,22 @@ void UpdateIndexUtility(storage::DataTable* table,
     double alpha = 0.2;
 
     // Update index utility
-    auto updated_average_index_utility = alpha * current_index_utility +
-        (1 - alpha) * average_index_utility;
+    auto updated_average_index_utility =
+        alpha * current_index_utility + (1 - alpha) * average_index_utility;
 
     index_metadata->SetUtility(updated_average_index_utility);
 
     LOG_TRACE("Updated index utility %5.2lf :: %s",
-              updated_average_index_utility,
-              index_metadata->GetInfo().c_str());
+              updated_average_index_utility, index_metadata->GetInfo().c_str());
   }
-
 }
 
-
 void PrintIndexInformation(storage::DataTable* table) {
-
   oid_t index_count = table->GetIndexCount();
   auto table_tilegroup_count = table->GetTileGroupCount();
   LOG_INFO("Index count : %u", index_count);
 
-  for(oid_t index_itr = 0; index_itr < index_count; index_itr++){
-
+  for (oid_t index_itr = 0; index_itr < index_count; index_itr++) {
     // Get index
     auto index = table->GetIndex(index_itr);
 
@@ -455,18 +415,17 @@ void PrintIndexInformation(storage::DataTable* table) {
 
     // Get percentage completion
     double fraction = 0.0;
-    if(table_tilegroup_count != 0){
-      fraction = (double) indexed_tile_group_offset / (double) table_tilegroup_count;
+    if (table_tilegroup_count != 0) {
+      fraction =
+          (double)indexed_tile_group_offset / (double)table_tilegroup_count;
       fraction *= 100;
     }
 
     LOG_INFO("%s %.1f%%", index->GetMetadata()->GetInfo().c_str(), fraction);
   }
-
 }
 
 void IndexTuner::Analyze(storage::DataTable* table) {
-
   // Process all samples in table
   auto& samples = table->GetIndexSamples();
 
@@ -485,7 +444,7 @@ void IndexTuner::Analyze(storage::DataTable* table) {
   // Drop indexes if needed
   auto index_creation_constraint = (max_indexes_allowed <= 0);
   auto write_intensive_workload = (average_write_ratio > write_ratio_threshold);
-  if(index_creation_constraint == true || write_intensive_workload == true) {
+  if (index_creation_constraint == true || write_intensive_workload == true) {
     DropIndexes(table);
   }
 
@@ -496,12 +455,10 @@ void IndexTuner::Analyze(storage::DataTable* table) {
   UpdateIndexUtility(table, sample_frequency_entry_list);
 
   // Display index information
-  //PrintIndexInformation(table);
-
+  // PrintIndexInformation(table);
 }
 
 void IndexTuner::IndexTuneHelper(storage::DataTable* table) {
-
   // Process all samples in table
   auto& samples = table->GetIndexSamples();
   auto sample_count = samples.size();
@@ -521,13 +478,11 @@ void IndexTuner::IndexTuneHelper(storage::DataTable* table) {
   table->ClearIndexSamples();
 }
 
-oid_t IndexTuner::GetIndexCount() const{
-
+oid_t IndexTuner::GetIndexCount() const {
   oid_t index_count = 0;
 
   // Go over all tables
-  for(auto table : tables) {
-
+  for (auto table : tables) {
     oid_t table_index_count = table->GetIndexCount();
 
     // Update index count
@@ -537,38 +492,29 @@ oid_t IndexTuner::GetIndexCount() const{
   return index_count;
 }
 
-void IndexTuner::Tune(){
-
-
+void IndexTuner::Tune() {
   // Continue till signal is not false
-  while(index_tuning_stop == false) {
-
+  while (index_tuning_stop == false) {
     // Go over all tables
-    for(auto table : tables) {
-
+    for (auto table : tables) {
       // Update indices periodically
       IndexTuneHelper(table);
-
     }
 
     // Sleep a bit
-    //std::this_thread::sleep_for(std::chrono::microseconds(sleep_duration));
-
+    // std::this_thread::sleep_for(std::chrono::microseconds(sleep_duration));
   }
-
 }
 
-void IndexTuner::Stop(){
-
+void IndexTuner::Stop() {
   // Stop tuning
   index_tuning_stop = true;
 
   // Stop thread
   index_tuner_thread.join();
-
 }
 
-void IndexTuner::AddTable(storage::DataTable* table){
+void IndexTuner::AddTable(storage::DataTable* table) {
   {
     std::lock_guard<std::mutex> lock(index_tuner_mutex);
     tables.push_back(table);
@@ -581,7 +527,6 @@ void IndexTuner::ClearTables() {
     tables.clear();
   }
 }
-
 
 }  // End brain namespace
 }  // End peloton namespace

--- a/src/include/benchmark/sdbench/sdbench_configuration.h
+++ b/src/include/benchmark/sdbench/sdbench_configuration.h
@@ -10,14 +10,13 @@
 //
 //===----------------------------------------------------------------------===//
 
-
 #pragma once
 
-#include <string>
 #include <getopt.h>
-#include <vector>
 #include <sys/time.h>
 #include <iostream>
+#include <string>
+#include <vector>
 
 #include "storage/data_table.h"
 
@@ -28,12 +27,12 @@ namespace sdbench {
 enum IndexUsageType {
   INDEX_USAGE_TYPE_INVALID = 0,
 
-  INDEX_USAGE_TYPE_AGGRESSIVE = 1,   // use partial indexes aggressively
-  INDEX_USAGE_TYPE_BALANCED = 2,     // use partial indexes balanced
-  INDEX_USAGE_TYPE_CONSERVATIVE = 3, // use partial indexes conservatively
-  INDEX_USAGE_TYPE_NEVER = 4,        // don't use indexes (no online tuning)
+  INDEX_USAGE_TYPE_AGGRESSIVE = 1,    // use partial indexes aggressively
+  INDEX_USAGE_TYPE_BALANCED = 2,      // use partial indexes balanced
+  INDEX_USAGE_TYPE_CONSERVATIVE = 3,  // use partial indexes conservatively
+  INDEX_USAGE_TYPE_NEVER = 4,         // don't use indexes (no online tuning)
 
-  INDEX_USAGE_TYPE_FULL = 5,         // only use full indexes
+  INDEX_USAGE_TYPE_FULL = 5,  // only use full indexes
 };
 
 enum QueryComplexityType {
@@ -45,6 +44,13 @@ enum QueryComplexityType {
 
 };
 
+enum WriteComplexityType {
+  WRITE_COMPLEXITY_TYPE_INVALID = 0,
+
+  WRITE_COMPLEXITY_TYPE_SIMPLE = 1,
+  WRITE_COMPLEXITY_TYPE_COMPLEX = 2
+};
+
 extern int orig_scale_factor;
 
 class configuration {
@@ -54,6 +60,9 @@ class configuration {
 
   // Complexity of the query.
   QueryComplexityType query_complexity_type;
+
+  // Complexity of update.
+  WriteComplexityType write_complexity_type;
 
   // size of the table
   int scale_factor;
@@ -70,7 +79,7 @@ class configuration {
   // column count
   int attribute_count;
 
-  // update ratio
+  // write ratio
   double write_ratio;
 
   // # of times to run operator
@@ -106,7 +115,6 @@ class configuration {
 
   // VARIABILITY PARAMETER
   oid_t variability_threshold;
-
 };
 
 void Usage(FILE *out);

--- a/src/include/brain/index_tuner.h
+++ b/src/include/brain/index_tuner.h
@@ -12,20 +12,20 @@
 
 #pragma once
 
-#include <vector>
-#include <mutex>
 #include <atomic>
+#include <mutex>
 #include <thread>
+#include <vector>
 
 #include "common/types.h"
 
 namespace peloton {
 
-namespace index{
+namespace index {
 class Index;
 }
 
-namespace storage{
+namespace storage {
 class DataTable;
 }
 
@@ -38,9 +38,7 @@ class Sample;
 //===--------------------------------------------------------------------===//
 
 class IndexTuner {
-
  public:
-
   IndexTuner(const IndexTuner &) = delete;
   IndexTuner &operator=(const IndexTuner &) = delete;
   IndexTuner(IndexTuner &&) = delete;
@@ -63,16 +61,16 @@ class IndexTuner {
   void Stop();
 
   // Add table to list of tables whose layout must be tuned
-  void AddTable(storage::DataTable* table);
+  void AddTable(storage::DataTable *table);
 
   // Clear list
   void ClearTables();
 
-  void SetSampleCountThreshold(const oid_t& sample_count_threshold_){
+  void SetSampleCountThreshold(const oid_t &sample_count_threshold_) {
     sample_count_threshold = sample_count_threshold_;
   }
 
-  void SetMaxTileGroupsIndexed(const oid_t& max_tile_groups_indexed_){
+  void SetMaxTileGroupsIndexed(const oid_t &max_tile_groups_indexed_) {
     max_tile_groups_indexed = max_tile_groups_indexed_;
   }
 
@@ -80,27 +78,25 @@ class IndexTuner {
   oid_t GetIndexCount() const;
 
  protected:
-
   // Index tuning helper
-  void IndexTuneHelper(storage::DataTable* table);
+  void IndexTuneHelper(storage::DataTable *table);
 
   void BuildIndex(storage::DataTable *table,
                   std::shared_ptr<index::Index> index);
 
   void BuildIndices(storage::DataTable *table);
 
-  void Analyze(storage::DataTable* table);
+  void Analyze(storage::DataTable *table);
 
   size_t CheckIndexStorageFootprint(storage::DataTable *table);
 
-  double ComputeWorkloadWriteRatio(const std::vector<brain::Sample>& samples);
+  double ComputeWorkloadWriteRatio(const std::vector<brain::Sample> &samples);
 
   void DropIndexes(storage::DataTable *table);
 
  private:
-
   // Tables whose indices must be tuned
-  std::vector<storage::DataTable*> tables;
+  std::vector<storage::DataTable *> tables;
 
   std::mutex index_tuner_mutex;
 
@@ -137,9 +133,7 @@ class IndexTuner {
 
   // index utility threshold
   double index_utility_threshold = 0.2;
-
 };
-
 
 }  // End brain namespace
 }  // End peloton namespace

--- a/src/include/executor/update_executor.h
+++ b/src/include/executor/update_executor.h
@@ -10,14 +10,16 @@
 //
 //===----------------------------------------------------------------------===//
 
-
 #pragma once
 
 #include <vector>
 
+#include "common/types.h"
 #include "executor/abstract_executor.h"
 #include "expression/abstract_expression.h"
 #include "planner/update_plan.h"
+#include "storage/tile.h"
+#include "storage/tile_group_header.h"
 
 namespace peloton {
 namespace executor {
@@ -34,6 +36,8 @@ class UpdateExecutor : public AbstractExecutor {
   bool DInit();
 
   bool DExecute();
+
+  void InplaceUpdate(storage::TileGroup *tile_group, ItemPointer location);
 
  private:
   storage::DataTable *target_table_ = nullptr;

--- a/src/include/index/index_key.h
+++ b/src/include/index/index_key.h
@@ -10,17 +10,16 @@
 //
 //===----------------------------------------------------------------------===//
 
-
 #pragma once
 
 #include <iostream>
 #include <sstream>
 
-#include "common/value_peeker.h"
 #include "common/logger.h"
 #include "common/macros.h"
-#include "storage/tuple.h"
+#include "common/value_peeker.h"
 #include "index/index.h"
+#include "storage/tuple.h"
 
 #include <boost/functional/hash.hpp>
 
@@ -135,8 +134,8 @@ class IntsKey {
        * byte location available
        * in the key and OR it in.
        */
-      data[key_offset] |=
-          (0xFF & (key_value >> (ii * 8))) << (intra_key_offset * 8);  //
+      data[key_offset] |= (0xFF & (key_value >> (ii * 8)))
+                          << (intra_key_offset * 8);  //
       intra_key_offset--;  // Move the offset inside the uint64 key back one.
       /*
        * If there are no more bytes available in the uint64_t indexed by
@@ -160,8 +159,8 @@ class IntsKey {
                                   int &intra_key_offset) const {
     uint64_t retval = 0;
     for (int ii = static_cast<int>(sizeof(KeyValueType)) - 1; ii >= 0; ii--) {
-      retval |=
-          (0xFF & (data[key_offset] >> (intra_key_offset * 8))) << (ii * 8);
+      retval |= (0xFF & (data[key_offset] >> (intra_key_offset * 8)))
+                << (ii * 8);
       intra_key_offset--;
       if (intra_key_offset < 0) {
         intra_key_offset = sizeof(uint64_t) - 1;
@@ -171,7 +170,8 @@ class IntsKey {
     return retval;
   }
 
-  const storage::Tuple GetTupleForComparison(const catalog::Schema *key_schema) const {
+  const storage::Tuple GetTupleForComparison(
+      const catalog::Schema *key_schema) const {
     return storage::Tuple(key_schema, data);
   }
 
@@ -186,21 +186,24 @@ class IntsKey {
           const uint64_t key_value =
               ExtractKeyValue<uint64_t>(key_offset, intra_key_offset);
           buffer << ConvertUnsignedValueToSignedValue<int64_t, INT64_MAX>(
-                        key_value) << ",";
+                        key_value)
+                 << ",";
           break;
         }
         case VALUE_TYPE_INTEGER: {
           const uint64_t key_value =
               ExtractKeyValue<uint32_t>(key_offset, intra_key_offset);
           buffer << ConvertUnsignedValueToSignedValue<int32_t, INT32_MAX>(
-                        key_value) << ",";
+                        key_value)
+                 << ",";
           break;
         }
         case VALUE_TYPE_SMALLINT: {
           const uint64_t key_value =
               ExtractKeyValue<uint16_t>(key_offset, intra_key_offset);
           buffer << ConvertUnsignedValueToSignedValue<int16_t, INT16_MAX>(
-                        key_value) << ",";
+                        key_value)
+                 << ",";
           break;
         }
         case VALUE_TYPE_TINYINT: {
@@ -208,12 +211,14 @@ class IntsKey {
               ExtractKeyValue<uint8_t>(key_offset, intra_key_offset);
           buffer << static_cast<int64_t>(
                         ConvertUnsignedValueToSignedValue<int8_t, INT8_MAX>(
-                            key_value)) << ",";
+                            key_value))
+                 << ",";
           break;
         }
         default:
-          throw IndexException("We currently only support a specific set of "
-                               "column index sizes...");
+          throw IndexException(
+              "We currently only support a specific set of "
+              "column index sizes...");
           break;
       }
     }
@@ -262,8 +267,9 @@ class IntsKey {
           break;
         }
         default:
-          throw IndexException("We currently only support a specific set of "
-                               "column index sizes...");
+          throw IndexException(
+              "We currently only support a specific set of "
+              "column index sizes...");
           break;
       }
     }
@@ -314,8 +320,9 @@ class IntsKey {
           break;
         }
         default:
-          throw IndexException("We currently only support a specific set of "
-                               "column index sizes...");
+          throw IndexException(
+              "We currently only support a specific set of "
+              "column index sizes...");
           break;
       }
     }
@@ -327,12 +334,10 @@ class IntsKey {
  private:
 };
 
-
 /** comparator for Int specialized indexes. */
 template <std::size_t KeySize>
 class IntsComparator {
  public:
-
   inline bool operator()(const IntsKey<KeySize> &lhs,
                          const IntsKey<KeySize> &rhs) const {
     // lexicographical compare could be faster for fixed N
@@ -359,9 +364,8 @@ class IntsComparator {
 template <std::size_t KeySize>
 class IntsComparatorRaw {
  public:
-
   inline int operator()(const IntsKey<KeySize> &lhs,
-                         const IntsKey<KeySize> &rhs) const {
+                        const IntsKey<KeySize> &rhs) const {
     // lexicographical compare could be faster for fixed N
     /*
      * Hopefully the compiler can unroll this loop
@@ -387,9 +391,9 @@ class IntsComparatorRaw {
 /**
  *
  */
-template <std::size_t KeySize> class IntsEqualityChecker {
+template <std::size_t KeySize>
+class IntsEqualityChecker {
  public:
-
   inline bool operator()(const IntsKey<KeySize> &lhs,
                          const IntsKey<KeySize> &rhs) const {
     for (unsigned int ii = 0; ii < KeySize; ii++) {
@@ -403,8 +407,8 @@ template <std::size_t KeySize> class IntsEqualityChecker {
     return true;
   }
 
-  IntsEqualityChecker(const IntsEqualityChecker &) {};
-  IntsEqualityChecker() {};
+  IntsEqualityChecker(const IntsEqualityChecker &){};
+  IntsEqualityChecker(){};
 };
 
 /**
@@ -424,9 +428,9 @@ struct IntsHasher : std::unary_function<IntsKey<KeySize>, std::size_t> {
   }
 
   const catalog::Schema *schema;
-  
+
   IntsHasher(const IntsHasher &) {}
-  IntsHasher() {};
+  IntsHasher(){};
 };
 
 /**
@@ -471,7 +475,6 @@ class GenericKey {
 template <std::size_t KeySize>
 class GenericComparator {
  public:
-
   inline bool operator()(const GenericKey<KeySize> &lhs,
                          const GenericKey<KeySize> &rhs) const {
     auto schema = lhs.schema;
@@ -502,9 +505,8 @@ class GenericComparator {
 template <std::size_t KeySize>
 class GenericComparatorRaw {
  public:
-
   inline int operator()(const GenericKey<KeySize> &lhs,
-                         const GenericKey<KeySize> &rhs) const {
+                        const GenericKey<KeySize> &rhs) const {
     auto schema = lhs.schema;
 
     for (oid_t column_itr = 0; column_itr < schema->GetColumnCount();
@@ -530,9 +532,9 @@ class GenericComparatorRaw {
 /**
  * Equality-checking function object
  */
-template <std::size_t KeySize> class GenericEqualityChecker {
+template <std::size_t KeySize>
+class GenericEqualityChecker {
  public:
-
   inline bool operator()(const GenericKey<KeySize> &lhs,
                          const GenericKey<KeySize> &rhs) const {
     auto schema = lhs.schema;
@@ -553,7 +555,6 @@ template <std::size_t KeySize> class GenericEqualityChecker {
  */
 template <std::size_t KeySize>
 struct GenericHasher : std::unary_function<GenericKey<KeySize>, std::size_t> {
-
   /** Generate a 64-bit number for the key value */
   inline size_t operator()(GenericKey<KeySize> const &p) const {
     auto schema = p.schema;
@@ -562,10 +563,9 @@ struct GenericHasher : std::unary_function<GenericKey<KeySize>, std::size_t> {
     pTuple.MoveToTuple(reinterpret_cast<const void *>(&p));
     return pTuple.HashCode();
   }
-  
-  GenericHasher(const GenericHasher &) {}
-  GenericHasher() {};
 
+  GenericHasher(const GenericHasher &) {}
+  GenericHasher(){};
 };
 
 /*
@@ -608,8 +608,7 @@ class TupleKey {
 
   // Set a key from a table-schema tuple.
   inline void SetFromTuple(const storage::Tuple *tuple, const int *indices,
-                           UNUSED_ATTRIBUTE const
-                           catalog::Schema *key_schema) {
+                           UNUSED_ATTRIBUTE const catalog::Schema *key_schema) {
     PL_ASSERT(tuple);
     PL_ASSERT(indices);
     column_indices = indices;
@@ -646,23 +645,21 @@ class TupleKey {
  * class TupleKeyHasher - Hash function for tuple keys
  */
 struct TupleKeyHasher {
-
   /** Generate a 64-bit number for the key value */
   inline size_t operator()(const TupleKey &p) const {
     storage::Tuple pTuple = p.GetTupleForComparison(p.key_tuple_schema);
     return pTuple.HashCode();
   }
-  
+
   /*
    * Copy Constructor - To make compiler happy
    */
   TupleKeyHasher(const TupleKeyHasher &) {}
-  TupleKeyHasher() {};
+  TupleKeyHasher(){};
 };
 
 class TupleKeyComparator {
  public:
-
   // return true if lhs < rhs
   inline bool operator()(const TupleKey &lhs, const TupleKey &rhs) const {
     storage::Tuple lhTuple = lhs.GetTupleForComparison(lhs.key_tuple_schema);
@@ -689,12 +686,11 @@ class TupleKeyComparator {
    * Copy constructor
    */
   TupleKeyComparator(const TupleKeyComparator &) {}
-  TupleKeyComparator() {};
+  TupleKeyComparator(){};
 };
 
 class TupleKeyComparatorRaw {
  public:
-
   // return -1 if a < b ;  0 if a == b ;  1 if a > b
   inline int operator()(const TupleKey &lhs, const TupleKey &rhs) const {
     storage::Tuple lhTuple = lhs.GetTupleForComparison(lhs.key_tuple_schema);
@@ -721,12 +717,11 @@ class TupleKeyComparatorRaw {
    * Copy constructor
    */
   TupleKeyComparatorRaw(const TupleKeyComparatorRaw &) {}
-  TupleKeyComparatorRaw() {};
+  TupleKeyComparatorRaw(){};
 };
 
 class TupleKeyEqualityChecker {
  public:
-
   // return true if lhs == rhs
   inline bool operator()(const TupleKey &lhs, const TupleKey &rhs) const {
     storage::Tuple lhTuple = lhs.GetTupleForComparison(lhs.key_tuple_schema);

--- a/src/include/storage/data_table.h
+++ b/src/include/storage/data_table.h
@@ -12,16 +12,17 @@
 
 #pragma once
 
-#include <memory>
-#include <queue>
 #include <map>
+#include <memory>
 #include <mutex>
+#include <queue>
 #include <set>
 
+#include "common/abstract_tuple.h"
 #include "common/platform.h"
-#include "storage/abstract_table.h"
 #include "container/lock_free_array.h"
 #include "index/index.h"
+#include "storage/abstract_table.h"
 
 //===--------------------------------------------------------------------===//
 // GUC Variables
@@ -228,6 +229,13 @@ class DataTable : public AbstractTable {
   // try to insert into the indices
   bool InsertInIndexes(const storage::Tuple *tuple, ItemPointer location);
 
+  // delete from specific index
+  bool DeleteInIndex(oid_t index_offset, const AbstractTuple *tuple,
+                     ItemPointer location);
+
+  // try to delete from indices
+  bool DeleteInIndexes(const AbstractTuple *tuple, ItemPointer location);
+
  protected:
   //===--------------------------------------------------------------------===//
   // INTEGRITY CHECKS
@@ -277,7 +285,8 @@ class DataTable : public AbstractTable {
   // set of current tile groups
   static constexpr std::size_t ACTIVE_TILE_GROUP_COUNT = 8;
 
-  std::shared_ptr<storage::TileGroup> last_tile_groups_[ACTIVE_TILE_GROUP_COUNT];
+  std::shared_ptr<storage::TileGroup>
+      last_tile_groups_[ACTIVE_TILE_GROUP_COUNT];
 
   // data table mutex
   std::mutex data_table_mutex_;

--- a/src/main/sdbench/sdbench_configuration.cpp
+++ b/src/main/sdbench/sdbench_configuration.cpp
@@ -26,6 +26,7 @@ void Usage() {
       "Command line options : sdbench <options>\n"
       "   -h --help                          :  Print help message\n"
       "   -f --index_usage_type              :  Types of indexes used\n"
+      "   -u --write_complexity_type         :  Complexity of write\n"
       "   -c --query_complexity_type         :  Complexity of query\n"
       "   -k --scale-factor                  :  # of tile groups\n"
       "   -a --attribute_count               :  # of attributes\n"
@@ -49,6 +50,7 @@ void Usage() {
 static struct option opts[] = {
     {"index_usage_type", optional_argument, NULL, 'f'},
     {"query_complexity_type", optional_argument, NULL, 'c'},
+    {"write_complexity_type", optional_argument, NULL, 'u'},
     {"scale-factor", optional_argument, NULL, 'k'},
     {"attribute_count", optional_argument, NULL, 'a'},
     {"write_ratio", optional_argument, NULL, 'w'},
@@ -119,6 +121,25 @@ static void ValidateQueryComplexityType(const configuration &state) {
         break;
       case QUERY_COMPLEXITY_TYPE_COMPLEX:
         LOG_INFO("%s : COMPLEX", "query_complexity_type ");
+        break;
+      default:
+        break;
+    }
+  }
+}
+
+static void ValidateWriteComplexityType(const configuration &state) {
+  if (state.write_complexity_type < 1 || state.write_complexity_type > 2) {
+    LOG_ERROR("Invalid write_complexity_type :: %d",
+              state.write_complexity_type);
+    exit(EXIT_FAILURE);
+  } else {
+    switch (state.write_complexity_type) {
+      case WRITE_COMPLEXITY_TYPE_SIMPLE:
+        LOG_INFO("write_complexity_type : SIMPLE");
+        break;
+      case WRITE_COMPLEXITY_TYPE_COMPLEX:
+        LOG_INFO("write_complexity_type : COMPLEX");
         break;
       default:
         break;
@@ -275,6 +296,7 @@ void ParseArguments(int argc, char *argv[], configuration &state) {
   state.scale_factor = 100.0;
   state.attribute_count = 20;
 
+  state.write_complexity_type = WRITE_COMPLEXITY_TYPE_SIMPLE;
   state.write_ratio = 0.0;
   state.tuples_per_tilegroup = DEFAULT_TUPLES_PER_TILEGROUP;
 
@@ -309,14 +331,18 @@ void ParseArguments(int argc, char *argv[], configuration &state) {
   // Parse args
   while (1) {
     int idx = 0;
-    int c = getopt_long(argc, argv, "hf:c:k:a:w:g:y:q:t:s:p:l:v:e:m:o:b:d:",
+    int c = getopt_long(argc, argv, "hf:c:k:a:w:g:y:q:t:s:p:l:v:e:m:o:b:d:u:",
                         opts, &idx);
 
     if (c == -1) break;
 
     switch (c) {
+      // AVAILABLE FLAGS: ijlnrxyzABCDEFGHIJKLMNOPQRSTUVWXYZ
       case 'f':
         state.index_usage_type = (IndexUsageType)atoi(optarg);
+        break;
+      case 'u':
+        state.write_complexity_type = (WriteComplexityType)atoi(optarg);
         break;
       case 'c':
         state.query_complexity_type = (QueryComplexityType)atoi(optarg);
@@ -381,6 +407,7 @@ void ParseArguments(int argc, char *argv[], configuration &state) {
   ValidateQueryComplexityType(state);
   ValidateScaleFactor(state);
   ValidateAttributeCount(state);
+  ValidateWriteComplexityType(state);
   ValidateWriteRatio(state);
   ValidateTuplesPerTileGroup(state);
   ValidateTotalOps(state);

--- a/src/main/sdbench/sdbench_configuration.cpp
+++ b/src/main/sdbench/sdbench_configuration.cpp
@@ -10,9 +10,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-
-#include <iomanip>
 #include <algorithm>
+#include <iomanip>
 
 #include "benchmark/sdbench/sdbench_configuration.h"
 #include "common/logger.h"
@@ -22,7 +21,8 @@ namespace benchmark {
 namespace sdbench {
 
 void Usage() {
-  LOG_INFO("\n"
+  LOG_INFO(
+      "\n"
       "Command line options : sdbench <options>\n"
       "   -h --help                          :  Print help message\n"
       "   -f --index_usage_type              :  Types of indexes used\n"
@@ -32,7 +32,8 @@ void Usage() {
       "   -w --write_ratio                   :  Fraction of writes\n"
       "   -g --tuples_per_tg                 :  # of tuples per tilegroup\n"
       "   -t --phase_length                  :  Length of a phase\n"
-      "   -q --total_ops                     :  Total # of ops, specify -1 to run until converge\n"
+      "   -q --total_ops                     :  Total # of ops, specify -1 to "
+      "run until converge\n"
       "   -s --selectivity                   :  Selectivity\n"
       "   -p --projectivity                  :  Projectivity\n"
       "   -l --layout                        :  Layout\n"
@@ -41,8 +42,7 @@ void Usage() {
       "   -o --convergence                   :  Convergence\n"
       "   -b --convergence_query_threshold   :  # of queries for convergence\n"
       "   -d --variability_threshold         :  Variability threshold\n"
-      "   -v --verbose                       :  Output verbosity\n"
-  );
+      "   -v --verbose                       :  Output verbosity\n");
   exit(EXIT_FAILURE);
 }
 
@@ -64,8 +64,7 @@ static struct option opts[] = {
     {"convergence_query_threshold", optional_argument, NULL, 'b'},
     {"variability_threshold", optional_argument, NULL, 'd'},
     {"verbose", optional_argument, NULL, 'v'},
-    {NULL, 0, NULL, 0}
-};
+    {NULL, 0, NULL, 0}};
 
 void GenerateSequence(oid_t column_count) {
   // Reset sequence
@@ -78,54 +77,53 @@ void GenerateSequence(oid_t column_count) {
   std::random_shuffle(sdbench_column_ids.begin(), sdbench_column_ids.end());
 }
 
-
 static void ValidateIndexUsageType(const configuration &state) {
   if (state.index_usage_type < 1 || state.index_usage_type > 5) {
-      LOG_ERROR("Invalid index_usage_type :: %d", state.index_usage_type);
-      exit(EXIT_FAILURE);
-  }
-  else {
-      switch (state.index_usage_type) {
-        case INDEX_USAGE_TYPE_CONSERVATIVE:
-          LOG_INFO("%s : CONSERVATIVE", "index_usage_type ");
-          break;
-        case INDEX_USAGE_TYPE_BALANCED:
-          LOG_INFO("%s : BALANCED", "index_usage_type ");
-          break;
-        case INDEX_USAGE_TYPE_AGGRESSIVE:
-          LOG_INFO("%s : AGGRESSIVE", "index_usage_type ");
-          break;
-        case INDEX_USAGE_TYPE_FULL:
-          LOG_INFO("%s : FULL", "index_usage_type ");
-          break;
-        case INDEX_USAGE_TYPE_NEVER:
-          LOG_INFO("%s : NEVER", "index_usage_type ");
-          break;
-        default:
-          break;
-      }
+    LOG_ERROR("Invalid index_usage_type :: %d", state.index_usage_type);
+    exit(EXIT_FAILURE);
+  } else {
+    switch (state.index_usage_type) {
+      case INDEX_USAGE_TYPE_CONSERVATIVE:
+        LOG_INFO("%s : CONSERVATIVE", "index_usage_type ");
+        break;
+      case INDEX_USAGE_TYPE_BALANCED:
+        LOG_INFO("%s : BALANCED", "index_usage_type ");
+        break;
+      case INDEX_USAGE_TYPE_AGGRESSIVE:
+        LOG_INFO("%s : AGGRESSIVE", "index_usage_type ");
+        break;
+      case INDEX_USAGE_TYPE_FULL:
+        LOG_INFO("%s : FULL", "index_usage_type ");
+        break;
+      case INDEX_USAGE_TYPE_NEVER:
+        LOG_INFO("%s : NEVER", "index_usage_type ");
+        break;
+      default:
+        break;
     }
+  }
 }
 
 static void ValidateQueryComplexityType(const configuration &state) {
   if (state.query_complexity_type < 1 || state.query_complexity_type > 3) {
-      LOG_ERROR("Invalid query_complexity_type :: %d", state.query_complexity_type);
-      exit(EXIT_FAILURE);
-    } else {
-      switch (state.query_complexity_type) {
-        case QUERY_COMPLEXITY_TYPE_SIMPLE:
-          LOG_INFO("%s : SIMPLE", "query_complexity_type ");
-          break;
-        case QUERY_COMPLEXITY_TYPE_MODERATE:
-          LOG_INFO("%s : MODERATE", "query_complexity_type ");
-          break;
-        case QUERY_COMPLEXITY_TYPE_COMPLEX:
-          LOG_INFO("%s : COMPLEX", "query_complexity_type ");
-          break;
-        default:
-          break;
-      }
+    LOG_ERROR("Invalid query_complexity_type :: %d",
+              state.query_complexity_type);
+    exit(EXIT_FAILURE);
+  } else {
+    switch (state.query_complexity_type) {
+      case QUERY_COMPLEXITY_TYPE_SIMPLE:
+        LOG_INFO("%s : SIMPLE", "query_complexity_type ");
+        break;
+      case QUERY_COMPLEXITY_TYPE_MODERATE:
+        LOG_INFO("%s : MODERATE", "query_complexity_type ");
+        break;
+      case QUERY_COMPLEXITY_TYPE_COMPLEX:
+        LOG_INFO("%s : COMPLEX", "query_complexity_type ");
+        break;
+      default:
+        break;
     }
+  }
 }
 
 static void ValidateScaleFactor(const configuration &state) {
@@ -223,7 +221,8 @@ static void ValidateTuplesPerTileGroup(const configuration &state) {
 
 static void ValidateSampleCountThreshold(const configuration &state) {
   if (state.sample_count_threshold <= 0) {
-    LOG_ERROR("Invalid sample_count_threshold :: %u", state.sample_count_threshold);
+    LOG_ERROR("Invalid sample_count_threshold :: %u",
+              state.sample_count_threshold);
     exit(EXIT_FAILURE);
   }
 
@@ -232,7 +231,8 @@ static void ValidateSampleCountThreshold(const configuration &state) {
 
 static void ValidateMaxTileGroupsIndexed(const configuration &state) {
   if (state.max_tile_groups_indexed <= 0) {
-    LOG_ERROR("Invalid max_tile_groups_indexed :: %u", state.max_tile_groups_indexed);
+    LOG_ERROR("Invalid max_tile_groups_indexed :: %u",
+              state.max_tile_groups_indexed);
     exit(EXIT_FAILURE);
   }
 
@@ -247,25 +247,26 @@ static void ValidateConvergence(const configuration &state) {
 
 static void ValidateQueryConvergenceThreshold(const configuration &state) {
   if (state.convergence_query_threshold <= 0) {
-    LOG_ERROR("Invalid convergence_query_threshold :: %u", state.convergence_query_threshold);
+    LOG_ERROR("Invalid convergence_query_threshold :: %u",
+              state.convergence_query_threshold);
     exit(EXIT_FAILURE);
   }
 
-  LOG_INFO("%s : %u", "convergence_query_threshold", state.convergence_query_threshold);
+  LOG_INFO("%s : %u", "convergence_query_threshold",
+           state.convergence_query_threshold);
 }
 
 static void ValidateVariabilityThreshold(const configuration &state) {
   if (state.variability_threshold <= 0 || state.variability_threshold > 25) {
-    LOG_ERROR("Invalid variability_threshold :: %u", state.variability_threshold);
+    LOG_ERROR("Invalid variability_threshold :: %u",
+              state.variability_threshold);
     exit(EXIT_FAILURE);
   }
 
   LOG_INFO("%s : %u", "variability_threshold", state.variability_threshold);
 }
 
-
 void ParseArguments(int argc, char *argv[], configuration &state) {
-
   // Default Values
   state.index_usage_type = INDEX_USAGE_TYPE_AGGRESSIVE;
   state.query_complexity_type = QUERY_COMPLEXITY_TYPE_SIMPLE;
@@ -308,16 +309,17 @@ void ParseArguments(int argc, char *argv[], configuration &state) {
   // Parse args
   while (1) {
     int idx = 0;
-    int c = getopt_long(argc, argv, "hf:c:k:a:w:g:y:q:t:s:p:l:v:e:m:o:b:d:", opts, &idx);
+    int c = getopt_long(argc, argv, "hf:c:k:a:w:g:y:q:t:s:p:l:v:e:m:o:b:d:",
+                        opts, &idx);
 
     if (c == -1) break;
 
     switch (c) {
       case 'f':
-        state.index_usage_type = (IndexUsageType) atoi(optarg);
+        state.index_usage_type = (IndexUsageType)atoi(optarg);
         break;
       case 'c':
-        state.query_complexity_type = (QueryComplexityType) atoi(optarg);
+        state.query_complexity_type = (QueryComplexityType)atoi(optarg);
         break;
       case 'k':
         state.scale_factor = atoi(optarg);
@@ -387,14 +389,14 @@ void ParseArguments(int argc, char *argv[], configuration &state) {
   ValidateProjectivity(state);
   ValidateLayout(state);
 
-  // Setup learning rate based on index usage type
-  if(state.index_usage_type == INDEX_USAGE_TYPE_CONSERVATIVE) {
+  // Setup learning rate based on index usage type. With a smaller
+  // sample_count_threashold, the index tuner will be more aggressive to adapt a
+  // new index.
+  if (state.index_usage_type == INDEX_USAGE_TYPE_CONSERVATIVE) {
     state.sample_count_threshold = 50;
-  }
-  else if(state.index_usage_type == INDEX_USAGE_TYPE_BALANCED) {
+  } else if (state.index_usage_type == INDEX_USAGE_TYPE_BALANCED) {
     state.sample_count_threshold = 10;
-  }
-  else if(state.index_usage_type == INDEX_USAGE_TYPE_AGGRESSIVE) {
+  } else if (state.index_usage_type == INDEX_USAGE_TYPE_AGGRESSIVE) {
     state.sample_count_threshold = 5;
   }
 
@@ -406,7 +408,6 @@ void ParseArguments(int argc, char *argv[], configuration &state) {
   ValidateConvergence(state);
   ValidateQueryConvergenceThreshold(state);
   ValidateVariabilityThreshold(state);
-
 }
 
 }  // namespace sdbench

--- a/src/main/sdbench/sdbench_workload.cpp
+++ b/src/main/sdbench/sdbench_workload.cpp
@@ -1045,6 +1045,8 @@ static void UpdateHelper(const std::vector<oid_t> &tuple_key_attrs,
   std::vector<executor::AbstractExecutor *> executors;
   executors.push_back(&update_executor);
 
+  update_executor.AddChild(&hybrid_scan_executor);
+
   /////////////////////////////////////////////////////////
   // COLLECT STATS
   /////////////////////////////////////////////////////////
@@ -1115,7 +1117,9 @@ static void RunSimpleUpdate() {
   for (auto tuple_key_attr : tuple_key_attrs) {
     os << tuple_key_attr << " ";
   }
-  LOG_TRACE("%s", os.str().c_str());
+  if (state.verbose) {
+    LOG_INFO("%s", os.str().c_str());
+  }
 
   UpdateHelper(tuple_key_attrs, index_key_attrs, update_attrs);
 }


### PR DESCRIPTION
This PR  adds the support for in-place update (without consistency guarantee), and adds update workload to sdbench. A list of implementation notes:

* Write workload is now all in-place update
* `-u` flag controls write (update) complexity. `-w` still controls write ratio
* to make sure that no values will be the same across tuples (to ensure the uniqueness of the index), updated attributes are the negative value of the original attribute
* There is no consistency guarantee of the update executor now, see the notes in `UpdateExecutor::InplaceUpdate()`
* Feel free to tune the predicate attrs and update attrs for update workload

@jarulraj 