### PR TITLE
Layout tuning

### DIFF
--- a/src/brain/layout_tuner.cpp
+++ b/src/brain/layout_tuner.cpp
@@ -11,7 +11,6 @@
 //===----------------------------------------------------------------------===//
 
 #include "brain/layout_tuner.h"
-#include "brain/clusterer.h"
 
 #include "catalog/schema.h"
 #include "common/logger.h"
@@ -20,36 +19,68 @@
 namespace peloton {
 namespace brain {
 
-LayoutTuner &LayoutTuner::GetInstance() {
+LayoutTuner& LayoutTuner::GetInstance() {
   static LayoutTuner layout_tuner;
   return layout_tuner;
 }
 
-LayoutTuner::LayoutTuner(){
+LayoutTuner::LayoutTuner() {
   // Nothing to do here !
 }
 
-LayoutTuner::~LayoutTuner(){
+LayoutTuner::~LayoutTuner() {
   // Nothing to do here !
 }
 
-void LayoutTuner::Start(){
-
+void LayoutTuner::Start() {
   // Set signal
   layout_tuning_stop = false;
 
   // Launch thread
   layout_tuner_thread = std::thread(&brain::LayoutTuner::Tune, this);
+}
 
+/**
+ * @brief Print information from column map, used to inspect layout generated
+ * from clusterer.
+ *
+ * @param column_map The column map to be printed.
+ */
+std::string LayoutTuner::GetColumnMapInfo(const column_map_type& column_map) {
+  std::stringstream ss;
+  std::map<oid_t, std::vector<oid_t>> tile_column_map;
+
+  // Construct a tile_id => [col_ids] map
+  for (auto itr = column_map.begin(); itr != column_map.end(); itr++) {
+    oid_t col_id = itr->first;
+    oid_t tile_id = itr->second.first;
+
+    if (tile_column_map.find(tile_id) == tile_column_map.end()) {
+      tile_column_map[tile_id] = {};
+    }
+
+    tile_column_map[tile_id].push_back(col_id);
+  }
+
+  // Construct a string from tile_col_map
+  for (auto itr = tile_column_map.begin(); itr != tile_column_map.end();
+       itr++) {
+    oid_t tile_id = itr->first;
+    ss << tile_id << ": ";
+    for (oid_t col_id : itr->second) {
+      ss << col_id << " ";
+    }
+    ss << " :: ";
+  }
+
+  return ss.str();
 }
 
 void LayoutTuner::UpdateDefaultPartition(storage::DataTable* table) {
   oid_t column_count = table->GetSchema()->GetColumnCount();
 
   // Set up clusterer
-  brain::Clusterer clusterer(cluster_count,
-                             column_count,
-                             new_sample_weight);
+  brain::Clusterer clusterer(cluster_count, column_count, new_sample_weight);
 
   // Process all samples in table
   auto& samples = table->GetLayoutSamples();
@@ -69,20 +100,17 @@ void LayoutTuner::UpdateDefaultPartition(storage::DataTable* table) {
   // Desired number of tiles
   auto layout = clusterer.GetPartitioning(tile_count);
 
+  LOG_TRACE("%s", GetColumnMapInfo(layout).c_str());
+
   // Update table layout
   table->SetDefaultLayout(layout);
-
 }
 
-void LayoutTuner::Tune(){
-
-
+void LayoutTuner::Tune() {
   // Continue till signal is not false
-  while(layout_tuning_stop == false) {
-
+  while (layout_tuning_stop == false) {
     // Go over all tables
-    for(auto table : tables) {
-
+    for (auto table : tables) {
       // Transform
       auto tile_group_count = table->GetTileGroupCount();
       auto tile_group_offset = rand() % tile_group_count;
@@ -95,25 +123,21 @@ void LayoutTuner::Tune(){
       // Sleep a bit
       std::this_thread::sleep_for(std::chrono::microseconds(sleep_duration));
     }
-
   }
-
 }
 
-void LayoutTuner::Stop(){
-
+void LayoutTuner::Stop() {
   // Stop tuning
   layout_tuning_stop = true;
 
   // Stop thread
   layout_tuner_thread.join();
-
 }
 
-void LayoutTuner::AddTable(storage::DataTable* table){
+void LayoutTuner::AddTable(storage::DataTable* table) {
   {
     std::lock_guard<std::mutex> lock(layout_tuner_mutex);
-    LOG_INFO("table : %p", table);
+    LOG_TRACE("Layout tuner adding table : %p", table);
 
     tables.push_back(table);
   }
@@ -125,7 +149,6 @@ void LayoutTuner::ClearTables() {
     tables.clear();
   }
 }
-
 
 }  // End brain namespace
 }  // End peloton namespace

--- a/src/brain/sample.cpp
+++ b/src/brain/sample.cpp
@@ -10,12 +10,13 @@
 //
 //===----------------------------------------------------------------------===//
 
-
-#include <sstream>
+#include <common/macros.h>
 #include <cmath>
 #include <iostream>
+#include <sstream>
 
 #include "brain/sample.h"
+#include "common/logger.h"
 
 namespace peloton {
 namespace brain {
@@ -62,6 +63,8 @@ Sample &Sample::operator+(const Sample &rhs) {
   size_t column_itr;
   size_t column_count = columns_accessed_.size();
 
+  PL_ASSERT(rhs.columns_accessed_.size() == column_count);
+
   for (column_itr = 0; column_itr < column_count; column_itr++) {
     auto other_val = rhs.columns_accessed_[column_itr];
     this->columns_accessed_[column_itr] += other_val;
@@ -87,19 +90,18 @@ const std::string Sample::GetInfo() const {
 
   os << "Sample :: ";
 
-  for (auto column : columns_accessed_) os << std::round(column) << " ";
+  for (auto column_value : columns_accessed_) os << column_value << " ";
 
   os << "  ::  " << std::round(metric_);
 
   return os.str();
 }
 
-bool Sample::operator==(const Sample &other) const{
-
+bool Sample::operator==(const Sample &other) const {
   auto sample_size = columns_accessed_.size();
 
-  for(oid_t sample_itr = 0; sample_itr < sample_size; sample_itr++){
-    if(columns_accessed_[sample_itr] != other.columns_accessed_[sample_itr]){
+  for (oid_t sample_itr = 0; sample_itr < sample_size; sample_itr++) {
+    if (columns_accessed_[sample_itr] != other.columns_accessed_[sample_itr]) {
       return false;
     }
   }

--- a/src/executor/materialization_executor.cpp
+++ b/src/executor/materialization_executor.cpp
@@ -10,7 +10,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-
 #include "executor/materialization_executor.h"
 
 #include <memory>
@@ -18,12 +17,12 @@
 
 #include "common/logger.h"
 #include "common/macros.h"
-#include "planner/materialization_plan.h"
 #include "executor/logical_tile.h"
 #include "executor/logical_tile_factory.h"
-#include "storage/tuple.h"
+#include "planner/materialization_plan.h"
 #include "storage/data_table.h"
 #include "storage/tile.h"
+#include "storage/tuple.h"
 
 namespace peloton {
 namespace executor {
@@ -48,7 +47,7 @@ void MaterializeColumnAtATime(
  */
 MaterializationExecutor::MaterializationExecutor(
     const planner::AbstractPlan *node, ExecutorContext *executor_context)
-: AbstractExecutor(node, executor_context) {}
+    : AbstractExecutor(node, executor_context) {}
 
 /**
  * @brief Nothing to init at the moment.
@@ -74,8 +73,8 @@ bool MaterializationExecutor::DInit() {
 void MaterializationExecutor::GenerateTileToColMap(
     const std::unordered_map<oid_t, oid_t> &old_to_new_cols,
     LogicalTile *source_tile,
-    std::unordered_map<storage::Tile *, std::vector<oid_t>> &
-    cols_in_physical_tile) {
+    std::unordered_map<storage::Tile *, std::vector<oid_t>>
+        &cols_in_physical_tile) {
   for (const auto &kv : old_to_new_cols) {
     oid_t col = kv.first;
 
@@ -101,7 +100,8 @@ void MaterializationExecutor::MaterializeByTiles(
     storage::Tile *dest_tile) {
   bool row_wise_materialization = true;
 
-  if (peloton_layout_mode == LAYOUT_TYPE_COLUMN) row_wise_materialization = false;
+  if (peloton_layout_mode == LAYOUT_TYPE_COLUMN)
+    row_wise_materialization = false;
 
   // TODO: Make this a parameter
   auto dest_tile_column_count = dest_tile->GetColumnCount();
@@ -374,7 +374,7 @@ bool MaterializationExecutor::DExecute() {
     physify_flag = node.GetPhysifyFlag();
 
     // Can't physify tile if we don't get a schema
-    if(node.GetSchema() == nullptr){
+    if (node.GetSchema() == nullptr) {
       physify_flag = false;
     }
   }

--- a/src/include/benchmark/sdbench/sdbench_configuration.h
+++ b/src/include/benchmark/sdbench/sdbench_configuration.h
@@ -51,6 +51,14 @@ enum WriteComplexityType {
   WRITE_COMPLEXITY_TYPE_COMPLEX = 2
 };
 
+// Copy from types.h for reference
+// typedef enum LayoutType {
+//   LAYOUT_TYPE_INVALID = 0,
+//   LAYOUT_TYPE_ROW = 1,    /* Pure row layout */
+//   LAYOUT_TYPE_COLUMN = 2, /* Pure column layout */
+//   LAYOUT_TYPE_HYBRID = 3  /* Hybrid layout */
+// } LayoutType;
+
 extern int orig_scale_factor;
 
 static const int generator_seed = 50;
@@ -90,12 +98,6 @@ class configuration {
   // total number of ops
   long total_ops;
 
-  // Adapt the layout ?
-  bool adapt_layout;
-
-  // Adapt the indexes ?
-  bool adapt_indexes;
-
   // Verbose output
   bool verbose;
 
@@ -128,7 +130,6 @@ class configuration {
 
   // write intensive workload ratio threshold
   double write_ratio_threshold;
-
 };
 
 void Usage(FILE *out);

--- a/src/include/brain/layout_tuner.h
+++ b/src/include/brain/layout_tuner.h
@@ -12,16 +12,17 @@
 
 #pragma once
 
-#include <vector>
-#include <mutex>
 #include <atomic>
+#include <mutex>
 #include <thread>
+#include <vector>
 
+#include "brain/clusterer.h"
 #include "common/types.h"
 
 namespace peloton {
 
-namespace storage{
+namespace storage {
 class DataTable;
 }
 
@@ -32,9 +33,7 @@ namespace brain {
 //===--------------------------------------------------------------------===//
 
 class LayoutTuner {
-
  public:
-
   LayoutTuner(const LayoutTuner &) = delete;
   LayoutTuner &operator=(const LayoutTuner &) = delete;
   LayoutTuner(LayoutTuner &&) = delete;
@@ -57,20 +56,20 @@ class LayoutTuner {
   void Stop();
 
   // Add table to list of tables whose layout must be tuned
-  void AddTable(storage::DataTable* table);
+  void AddTable(storage::DataTable *table);
 
   // Clear list
   void ClearTables();
 
  protected:
-
   // Update layout of table
-  void UpdateDefaultPartition(storage::DataTable* table);
+  void UpdateDefaultPartition(storage::DataTable *table);
+
+  std::string GetColumnMapInfo(const column_map_type &column_map);
 
  private:
-
   // Tables whose layout must be tuned
-  std::vector<storage::DataTable*> tables;
+  std::vector<storage::DataTable *> tables;
 
   std::mutex layout_tuner_mutex;
 
@@ -85,7 +84,7 @@ class LayoutTuner {
   //===--------------------------------------------------------------------===//
 
   // Layout similarity threshold
-  double theta = 0.0;
+  double theta = 0.3;
 
   // Sleeping period (in us)
   oid_t sleep_duration = 100;
@@ -98,9 +97,7 @@ class LayoutTuner {
 
   // Desired layout tile count
   oid_t tile_count = 2;
-
 };
-
 
 }  // End brain namespace
 }  // End peloton namespace

--- a/src/include/brain/layout_tuner.h
+++ b/src/include/brain/layout_tuner.h
@@ -84,7 +84,12 @@ class LayoutTuner {
   //===--------------------------------------------------------------------===//
 
   // Layout similarity threshold
-  double theta = 0.3;
+  // NOTE:
+  // This could be very sensitive, the measurement of schema difference in
+  // datatable is divided by column_count, so could be very small. Theta should
+  // also not be set to zero, otherwise it will always trigger
+  // DataTable::TransformTileGroup, even if the schema is the same.
+  double theta = 0.0001;
 
   // Sleeping period (in us)
   oid_t sleep_duration = 100;
@@ -96,6 +101,8 @@ class LayoutTuner {
   double new_sample_weight = 0.01;
 
   // Desired layout tile count
+  // FIXME: for join query, only two tiles in the tile group is not enough,
+  // should be 3 = 2 for projected columns from two tables + 1 (other columns)
   oid_t tile_count = 2;
 };
 

--- a/src/include/brain/sample.h
+++ b/src/include/brain/sample.h
@@ -10,14 +10,13 @@
 //
 //===----------------------------------------------------------------------===//
 
-
 #pragma once
 
 #include <vector>
 
 #include "common/printable.h"
-#include "common/types.h"
 #include "common/printable.h"
+#include "common/types.h"
 
 namespace peloton {
 namespace brain {
@@ -29,8 +28,8 @@ namespace brain {
 enum SampleType {
   SAMPLE_TYPE_INVALID = 0,
 
-  SAMPLE_TYPE_ACCESS = 1,       // accessed attributes
-  SAMPLE_TYPE_UPDATE = 2        // updated attributes
+  SAMPLE_TYPE_ACCESS = 1,  // accessed attributes
+  SAMPLE_TYPE_UPDATE = 2   // updated attributes
 };
 
 //===--------------------------------------------------------------------===//
@@ -52,7 +51,7 @@ class Sample : public Printable {
       : columns_accessed_(columns_accessed),
         weight_(weight),
         sample_type_(sample_type),
-        metric_(metric){}
+        metric_(metric) {}
 
   // get the distance from other sample
   double GetDistance(const Sample &other) const;
@@ -97,21 +96,16 @@ class Sample : public Printable {
 namespace std {
 
 template <>
-struct hash<peloton::brain::Sample>
-{
-  size_t operator()(const peloton::brain::Sample& sample) const
-  {
+struct hash<peloton::brain::Sample> {
+  size_t operator()(const peloton::brain::Sample &sample) const {
     // Compute individual hash values using XOR and bit shifting:
     long hash = 31;
     auto sample_size = sample.columns_accessed_.size();
-    for(size_t sample_itr = 0; sample_itr < sample_size; sample_itr++){
-      hash *= ( sample.columns_accessed_[sample_itr] + 31);
+    for (size_t sample_itr = 0; sample_itr < sample_size; sample_itr++) {
+      hash *= (sample.columns_accessed_[sample_itr] + 31);
     }
 
     return hash;
   }
 };
-
 }
-
-

--- a/src/main/sdbench/sdbench_configuration.cpp
+++ b/src/main/sdbench/sdbench_configuration.cpp
@@ -45,8 +45,7 @@ void Usage() {
       "   -w --write_ratio                   :  Fraction of writes\n"
       "   -x --index_count_threshold         :  Index count threshold\n"
       "   -y --index_utility_threshold       :  Index utility threshold\n"
-      "   -z --write_ratio_threshold         :  Write ratio threshold\n"
-  );
+      "   -z --write_ratio_threshold         :  Write ratio threshold\n");
   exit(EXIT_FAILURE);
 }
 
@@ -72,8 +71,7 @@ static struct option opts[] = {
     {"index_count_threshold", optional_argument, NULL, 'x'},
     {"index_utility_threshold", optional_argument, NULL, 'y'},
     {"write_ratio_threshold", optional_argument, NULL, 'z'},
-    {NULL, 0, NULL, 0}
-};
+    {NULL, 0, NULL, 0}};
 
 void GenerateSequence(oid_t column_count) {
   // Reset sequence
@@ -219,20 +217,15 @@ static void ValidateWriteRatio(const configuration &state) {
 
   if (state.write_ratio == 0) {
     LOG_INFO("%s : READ_ONLY", "write_ratio");
-  }
-  else if (state.write_ratio == 0.1) {
+  } else if (state.write_ratio == 0.1) {
     LOG_INFO("%s : READ_HEAVY", "write_ratio");
-  }
-  else if (state.write_ratio == 0.5) {
+  } else if (state.write_ratio == 0.5) {
     LOG_INFO("%s : BALANCED", "write_ratio");
-  }
-  else if (state.write_ratio == 0.9) {
+  } else if (state.write_ratio == 0.9) {
     LOG_INFO("%s : WRITE_HEAVY", "write_ratio");
-  }
-  else {
+  } else {
     LOG_INFO("%s : %.1lf", "write_ratio", state.write_ratio);
   }
-
 }
 
 static void ValidateTotalOps(const configuration &state) {
@@ -326,7 +319,8 @@ static void ValidateIndexUtilityThreshold(const configuration &state) {
     exit(EXIT_FAILURE);
   }
 
-  LOG_INFO("%s : %.2lf", "index_utility_threshold", state.index_utility_threshold);
+  LOG_INFO("%s : %.2lf", "index_utility_threshold",
+           state.index_utility_threshold);
 }
 
 static void ValidateWriteRatioThreshold(const configuration &state) {
@@ -340,7 +334,6 @@ static void ValidateWriteRatioThreshold(const configuration &state) {
 }
 
 void ParseArguments(int argc, char *argv[], configuration &state) {
-
   state.verbose = false;
 
   // Default Values
@@ -366,10 +359,6 @@ void ParseArguments(int argc, char *argv[], configuration &state) {
   // Layout parameter
   state.layout_mode = LAYOUT_TYPE_ROW;
 
-  // Adapt parameters
-  state.adapt_layout = false;
-  state.adapt_indexes = true;
-
   // Learning rate
   state.sample_count_threshold = 10;
   state.max_tile_groups_indexed = 10;
@@ -389,8 +378,8 @@ void ParseArguments(int argc, char *argv[], configuration &state) {
   // Parse args
   while (1) {
     int idx = 0;
-    int c = getopt_long(argc, argv, "a:b:c:d:e:f:g:hk:l:m:o:p:q:s:t:u:v:w:x:y:z:",
-                        opts, &idx);
+    int c = getopt_long(
+        argc, argv, "a:b:c:d:e:f:g:hk:l:m:o:p:q:s:t:u:v:w:x:y:z:", opts, &idx);
 
     if (c == -1) break;
 

--- a/src/main/sdbench/sdbench_loader.cpp
+++ b/src/main/sdbench/sdbench_loader.cpp
@@ -10,33 +10,32 @@
 //
 //===----------------------------------------------------------------------===//
 
-
 #include "benchmark/sdbench/sdbench_loader.h"
 #include "benchmark/sdbench/sdbench_configuration.h"
 
+#include <chrono>
+#include <ctime>
+#include <iostream>
 #include <memory>
 #include <string>
 #include <unordered_map>
 #include <vector>
-#include <chrono>
-#include <iostream>
-#include <ctime>
 
 #include "catalog/manager.h"
 #include "catalog/schema.h"
+#include "common/logger.h"
+#include "common/macros.h"
 #include "concurrency/transaction.h"
 #include "concurrency/transaction_manager_factory.h"
-#include "common/macros.h"
-#include "common/logger.h"
 #include "executor/abstract_executor.h"
 #include "executor/insert_executor.h"
 #include "expression/constant_value_expression.h"
 #include "index/index_factory.h"
 #include "planner/insert_plan.h"
-#include "storage/tile.h"
-#include "storage/tile_group.h"
 #include "storage/data_table.h"
 #include "storage/table_factory.h"
+#include "storage/tile.h"
+#include "storage/tile_group.h"
 
 namespace peloton {
 namespace benchmark {
@@ -71,7 +70,6 @@ void CreateTable() {
   sdbench_table.reset(storage::TableFactory::GetDataTable(
       INVALID_OID, INVALID_OID, table_schema, table_name,
       state.tuples_per_tilegroup, own_schema, adapt_table));
-
 }
 
 void LoadTable() {
@@ -120,10 +118,8 @@ void CreateAndLoadTable(LayoutType layout_type) {
 }
 
 void DropIndexes() {
-
   // Drop index
   sdbench_table->DropIndexes();
-
 }
 
 }  // namespace sdbench

--- a/src/main/sdbench/sdbench_workload.cpp
+++ b/src/main/sdbench/sdbench_workload.cpp
@@ -779,6 +779,7 @@ static void JoinQueryHelper(
   /////////////////////////////////////////////////////////
 
   // Create and set up materialization executor
+  // FIXME: this will always retreive all columns, projectivity is ignored
   std::vector<catalog::Column> output_columns;
   std::unordered_map<oid_t, oid_t> old_to_new_cols;
   oid_t join_column_count = column_count * 2;

--- a/src/main/sdbench/sdbench_workload.cpp
+++ b/src/main/sdbench/sdbench_workload.cpp
@@ -375,7 +375,7 @@ static std::shared_ptr<index::Index> PickIndex(storage::DataTable *table,
 
     auto index = table->GetIndex(index_itr);
     // Check if index exists
-    if(index == nullptr){
+    if (index == nullptr) {
       continue;
     }
 
@@ -638,7 +638,7 @@ static void RunComplexQuery() {
   } else if (is_aggregate_query == true) {
     LOG_TRACE("Complex :: %s", GetOidVectorString(left_table_tuple_key_attrs +
                                                   right_table_tuple_key_attrs)
-              .c_str());
+                                   .c_str());
   } else {
     LOG_ERROR("Invalid query \n");
     return;
@@ -717,8 +717,8 @@ static void JoinQueryHelper(
                                            right_table_join_column);
 
   std::unique_ptr<expression::ComparisonExpression<expression::CmpLt>>
-  join_predicate(new expression::ComparisonExpression<expression::CmpLt>(
-      EXPRESSION_TYPE_COMPARE_LESSTHAN, left_table_attr, right_table_attr));
+      join_predicate(new expression::ComparisonExpression<expression::CmpLt>(
+          EXPRESSION_TYPE_COMPARE_LESSTHAN, left_table_attr, right_table_attr));
 
   std::unique_ptr<const planner::ProjectInfo> project_info(nullptr);
   std::shared_ptr<const catalog::Schema> schema(nullptr);
@@ -779,8 +779,7 @@ static void JoinQueryHelper(
   auto selectivity = state.selectivity;
 
   ExecuteTest(
-      executors,
-      brain::SAMPLE_TYPE_ACCESS,
+      executors, brain::SAMPLE_TYPE_ACCESS,
       {left_table_index_columns_accessed, right_table_index_columns_accessed},
       selectivity);
 
@@ -851,7 +850,7 @@ static void AggregateQueryHelper(const std::vector<oid_t> &tuple_key_attrs,
         EXPRESSION_TYPE_AGGREGATE_MAX,
         expression::ExpressionUtil::TupleValueFactory(VALUE_TYPE_INTEGER, 0,
                                                       column_id),
-                                                      false);
+        false);
     agg_terms.push_back(max_column_agg);
   }
 
@@ -921,9 +920,7 @@ static void AggregateQueryHelper(const std::vector<oid_t> &tuple_key_attrs,
                                              tuple_key_attrs.end());
   auto selectivity = state.selectivity;
 
-  ExecuteTest(executors,
-              brain::SAMPLE_TYPE_ACCESS,
-              {index_columns_accessed},
+  ExecuteTest(executors, brain::SAMPLE_TYPE_ACCESS, {index_columns_accessed},
               selectivity);
 
   txn_manager.CommitTransaction();
@@ -1022,9 +1019,7 @@ static void UpdateHelper(const std::vector<oid_t> &tuple_key_attrs,
                                              tuple_key_attrs.end());
   auto selectivity = state.selectivity;
 
-  ExecuteTest(executors,
-              brain::SAMPLE_TYPE_UPDATE,
-              {index_columns_accessed},
+  ExecuteTest(executors, brain::SAMPLE_TYPE_UPDATE, {index_columns_accessed},
               selectivity);
 
   txn_manager.CommitTransaction();
@@ -1086,7 +1081,6 @@ static void RunSimpleUpdate() {
   for (oid_t txn_itr = 0; txn_itr < state.phase_length; txn_itr++) {
     UpdateHelper(tuple_key_attrs, index_key_attrs, update_attrs);
   }
-
 }
 
 static void RunComplexUpdate() {
@@ -1143,7 +1137,6 @@ static void RunComplexUpdate() {
   for (oid_t txn_itr = 0; txn_itr < state.phase_length; txn_itr++) {
     UpdateHelper(tuple_key_attrs, index_key_attrs, update_attrs);
   }
-
 }
 
 /**
@@ -1217,7 +1210,7 @@ static bool HasIndexConfigurationConverged() {
   for (oid_t index_itr = 0; index_itr < index_count; index_itr++) {
     // Get index
     auto index = sdbench_table->GetIndex(index_itr);
-    if(index == nullptr){
+    if (index == nullptr) {
       continue;
     }
 
@@ -1278,7 +1271,6 @@ static bool HasIndexConfigurationConverged() {
 }
 
 void RunSDBenchTest() {
-
   // Setup index tuner
   index_tuner.SetSampleCountThreshold(state.sample_count_threshold);
   index_tuner.SetMaxTileGroupsIndexed(state.max_tile_groups_indexed);
@@ -1319,7 +1311,7 @@ void RunSDBenchTest() {
   Timer<> index_unchanged_timer;
 
   // Start index tuner
-  if(state.index_usage_type != INDEX_USAGE_TYPE_NEVER){
+  if (state.index_usage_type != INDEX_USAGE_TYPE_NEVER) {
     index_tuner.AddTable(sdbench_table.get());
 
     // Start after adding tables
@@ -1344,15 +1336,14 @@ void RunSDBenchTest() {
     // Check index convergence
     if (state.convergence == true) {
       bool converged = HasIndexConfigurationConverged();
-      if(converged == true) {
+      if (converged == true) {
         break;
       }
     }
-
   }
 
   // Stop index tuner
-  if(state.index_usage_type != INDEX_USAGE_TYPE_NEVER){
+  if (state.index_usage_type != INDEX_USAGE_TYPE_NEVER) {
     index_tuner.Stop();
     index_tuner.ClearTables();
   }
@@ -1361,7 +1352,6 @@ void RunSDBenchTest() {
   DropIndexes();
 
   // Reset
-  state.adapt_layout = false;
   query_itr = 0;
 
   LOG_INFO("Duration : %.2lf", total_duration);


### PR DESCRIPTION
This PR adds layout tuning to the benchmark, some implementation notes:
- Index tuner and layout tuner use `Sample` in different ways. It took me quite a while to find out that index tuner uses the samples as access bitmap.
- Layout tuning is configured by the `-l` flag, 1 is `ROW` layout, 2 is `COLUMN` layout and 3 is `HYBRID`
- The samples for layout tuner are passed in as the third arguments of `ExecuteTest`, we can tweak on this input to provide the hints we want to give to layout tuner. One optimization will be, for a given workload, decouple the indexed columns accessed and tuple columns accessed (during materialization), so that the index is tuned for the predicate pattern, and layout is tuned for column access pattern.
- I have done a sanity check with `simple query`, `HYBRID` works better than the other two when: selectivity is large, projectivity is small and table is wide
