### PR TITLE
Tuner time breakdown + holistic index fix

### DIFF
--- a/src/brain/index_tuner.cpp
+++ b/src/brain/index_tuner.cpp
@@ -33,26 +33,33 @@ IndexTuner& IndexTuner::GetInstance() {
 }
 
 IndexTuner::IndexTuner() {
+  tile_groups_indexed_ = 0;
   // Nothing to do here !
 }
 
 IndexTuner::~IndexTuner() {
   // Calculate stats
-  double build_indices_mean, analyze_mean, add_indexes_mean, update_index_util_mean;
-  double build_indices_sum, analyze_sum, add_indexes_sum, update_index_util_sum;
+  double build_indices_mean, analyze_mean, update_index_util_mean, add_indexes_mean, get_suggested_indexes_mean, get_frequent_samples_mean, compute_rw_ratio_mean;
+  double build_indices_sum, analyze_sum, update_index_util_sum, add_indexes_sum, get_suggested_indexes_sum, get_frequent_samples_sum, compute_rw_ratio_sum;
   CalculateStatistics(build_indices_times_, build_indices_mean, build_indices_sum);
   CalculateStatistics(analyze_times_, analyze_mean, analyze_sum);
-  CalculateStatistics(add_indexes_times_, add_indexes_mean, add_indexes_sum);
   CalculateStatistics(update_index_util_times_, update_index_util_mean, update_index_util_sum);
+  CalculateStatistics(add_indexes_times_, add_indexes_mean, add_indexes_sum);
+  CalculateStatistics(get_suggested_indexes_times_, get_suggested_indexes_mean, get_suggested_indexes_sum);
+  CalculateStatistics(get_frequent_samples_times_, get_frequent_samples_mean, get_frequent_samples_sum);
+  CalculateStatistics(compute_rw_ratio_times_, compute_rw_ratio_mean, compute_rw_ratio_sum);
 
-  LOG_INFO("%s: %f ms", "Total build index time: ", build_indices_sum);
-  LOG_INFO("%s: %f ms", "Total analyze index time: ", analyze_sum);
-  LOG_INFO("%s: %f ms", "Total add index time: ", add_indexes_sum);
-  LOG_INFO("%s: %f ms", "Total update index util time: ", update_index_util_sum);
-  LOG_INFO("%s: %f ms", "Average build index time: ", build_indices_mean);
-  LOG_INFO("%s: %f ms", "Average analyze index time: ", analyze_mean);
-  LOG_INFO("%s: %f ms", "Average add index time: ", add_indexes_mean);
-  LOG_INFO("%s: %f ms", "Average update index util time: ", update_index_util_mean);
+  analyze_sum = update_index_util_sum + add_indexes_sum + get_suggested_indexes_sum + get_frequent_samples_sum + compute_rw_ratio_sum;
+
+  LOG_INFO("\t[INDEX]\t%s\t%f ms", "Total build index time ", build_indices_sum);
+  LOG_INFO("\t[INDEX]\t%s\t%d ", "Total tile groups indexed", tile_groups_indexed_);
+  LOG_INFO("\t[INDEX]\t%s\t%f ms", "Avg build index time ", build_indices_sum / tile_groups_indexed_);
+  LOG_INFO("\t[INDEX]\t%s\t%f ms", "Total analyze index time ", analyze_sum);
+  LOG_INFO("\t[INDEX]\t%s\t%f ms\t%lf%%", "GetFrequentSamples() ", get_frequent_samples_sum, get_frequent_samples_sum / analyze_sum * 100);
+  LOG_INFO("\t[INDEX]\t%s\t%f ms\t%lf%%", "ComputeWorkloadWriteRatio() ", compute_rw_ratio_sum, compute_rw_ratio_sum / analyze_sum * 100);
+  LOG_INFO("\t[INDEX]\t%s\t%f ms\t%lf%%", "GetSuggestedIndices() ", get_suggested_indexes_sum, get_suggested_indexes_sum / analyze_sum * 100);
+  LOG_INFO("\t[INDEX]\t%s\t%f ms\t%lf%%", "AddIndexes() ", add_indexes_sum, add_indexes_sum / analyze_sum * 100);
+  LOG_INFO("\t[INDEX]\t%s\t%f ms\t%lf%%", "UpdateIndexUtility() ", update_index_util_sum, update_index_util_sum / analyze_sum * 100);
 }
 
 void IndexTuner::CalculateStatistics(const std::vector<double> data, double &mean, double &sum) {
@@ -157,6 +164,8 @@ void IndexTuner::BuildIndex(storage::DataTable* table,
     index_tile_group_offset++;
     tile_groups_indexed++;
   }
+
+  tile_groups_indexed_ += tile_groups_indexed;
 }
 
 void IndexTuner::BuildIndices(storage::DataTable* table) {
@@ -460,18 +469,29 @@ void PrintIndexInformation(storage::DataTable* table) {
 
 void IndexTuner::Analyze(storage::DataTable* table) {
   Timer<std::milli> timer;
-  timer.Start();
   // Process all samples in table
   auto& samples = table->GetIndexSamples();
 
   // Check write ratio
+  timer.Start();
   auto average_write_ratio = ComputeWorkloadWriteRatio(samples);
+  timer.Stop();
+  compute_rw_ratio_times_.push_back(timer.GetDuration());
+  timer.Reset();
 
   // Determine frequent samples
+  timer.Start();
   auto sample_frequency_entry_list = GetFrequentSamples(samples);
+  timer.Stop();
+  get_frequent_samples_times_.push_back(timer.GetDuration());
+  timer.Reset();
 
   // Compute suggested indices
+  timer.Start();
   auto suggested_indices = GetSuggestedIndices(sample_frequency_entry_list);
+  timer.Stop();
+  get_suggested_indexes_times_.push_back(timer.GetDuration());
+  timer.Reset();
 
   // Check index storage footprint
   auto valid_index_count = table->GetValidIndexCount();
@@ -485,9 +505,7 @@ void IndexTuner::Analyze(storage::DataTable* table) {
   auto index_overflow = (valid_index_count > index_count_threshold);
   auto write_intensive_workload = (average_write_ratio > write_ratio_threshold);
 
-  // Skip drop table
-  timer.Stop();
-  analyze_times_.push_back(timer.GetDuration());
+  // Skip drop table time
   if (index_overflow == true || write_intensive_workload == true) {
     DropIndexes(table);
   }
@@ -497,11 +515,14 @@ void IndexTuner::Analyze(storage::DataTable* table) {
   AddIndexes(table, suggested_indices);
   timer.Stop();
   add_indexes_times_.push_back(timer.GetDuration());
+  timer.Reset();
 
   // Update index utility
   timer.Start();
   UpdateIndexUtility(table, sample_frequency_entry_list);
+  timer.Stop();
   update_index_util_times_.push_back(timer.GetDuration());
+  timer.Reset();
 
   // Display index information
   PrintIndexInformation(table);

--- a/src/brain/layout_tuner.cpp
+++ b/src/brain/layout_tuner.cpp
@@ -27,7 +27,7 @@ LayoutTuner& LayoutTuner::GetInstance() {
 
 LayoutTuner::LayoutTuner() {
   // Nothing to do here !
-  tilegroup_transformed_ = 0;
+  tile_groups_transformed_ = 0;
 }
 
 LayoutTuner::~LayoutTuner() {
@@ -39,12 +39,9 @@ LayoutTuner::~LayoutTuner() {
   CalculateStatistics(update_default_partition_times_, update_default_partition_mean, update_default_partition_sum);
 
   LOG_INFO("\t[LAYOUT]\tTotal transform tilegroup time\t%lf ms", transform_tg_sum);
-  LOG_INFO("\t[LAYOUT]\tTotal tile group transformed\t%d", (int)tilegroup_transformed_);
-  LOG_INFO("\t[LAYOUT]\tAverage transform tilegroup time\t%lf ms", transform_tg_sum / tilegroup_transformed_);
+  LOG_INFO("\t[LAYOUT]\tTotal tile group transformed\t%d", (int)tile_groups_transformed_);
+  LOG_INFO("\t[LAYOUT]\tAverage transform tilegroup time\t%lf ms", transform_tg_sum / tile_groups_transformed_);
   LOG_INFO("\t[LAYOUT]\tTotal update partition time\t%lf ms", update_default_partition_sum);
-  // LOG_INFO("[LAYOUT] Average transform tilegroup time: %lf ms", transform_tg_mean);
-  // LOG_INFO("[LAYOUT] Average update partition time: %lf ms", update_default_partition_mean);
-
 }
 
 void LayoutTuner::Start() {
@@ -148,7 +145,7 @@ void LayoutTuner::Tune() {
 
       timer.Start();
       if (table->TransformTileGroup(tile_group_offset, theta) != nullptr) {
-        tilegroup_transformed_ += 1;
+        tile_groups_transformed_ += 1;
       }
       timer.Stop();
       transform_tg_times_.push_back(timer.GetDuration());

--- a/src/include/brain/index_tuner.h
+++ b/src/include/brain/index_tuner.h
@@ -116,6 +116,8 @@ class IndexTuner {
 
   void DropIndexes(storage::DataTable *table);
 
+  void CalculateStatistics(const std::vector<double> data, double &mean, double &sum);
+
  private:
   // Tables whose indices must be tuned
   std::vector<storage::DataTable *> tables;
@@ -165,6 +167,11 @@ class IndexTuner {
   // write intensive workload ratio threshold
   double write_ratio_threshold = 0.75;
 
+  // Profile timer
+  std::vector<double> build_indices_times_;
+  std::vector<double> analyze_times_;
+  std::vector<double> add_indexes_times_;
+  std::vector<double> update_index_util_times_;
 };
 
 }  // End brain namespace

--- a/src/include/brain/index_tuner.h
+++ b/src/include/brain/index_tuner.h
@@ -167,11 +167,16 @@ class IndexTuner {
   // write intensive workload ratio threshold
   double write_ratio_threshold = 0.75;
 
-  // Profile timer
+  // Profile time
   std::vector<double> build_indices_times_;
   std::vector<double> analyze_times_;
   std::vector<double> add_indexes_times_;
   std::vector<double> update_index_util_times_;
+  std::vector<double> compute_rw_ratio_times_;
+  std::vector<double> get_suggested_indexes_times_;
+  std::vector<double> get_frequent_samples_times_;
+
+  oid_t tile_groups_indexed_;
 };
 
 }  // End brain namespace

--- a/src/include/brain/layout_tuner.h
+++ b/src/include/brain/layout_tuner.h
@@ -19,6 +19,7 @@
 
 #include "brain/clusterer.h"
 #include "common/types.h"
+#include "common/timer.h"
 
 namespace peloton {
 
@@ -67,6 +68,8 @@ class LayoutTuner {
 
   std::string GetColumnMapInfo(const column_map_type &column_map);
 
+  void CalculateStatistics(const std::vector<double> data, double &mean, double &sum);
+
  private:
   // Tables whose layout must be tuned
   std::vector<storage::DataTable *> tables;
@@ -104,6 +107,11 @@ class LayoutTuner {
   // FIXME: for join query, only two tiles in the tile group is not enough,
   // should be 3 = 2 for projected columns from two tables + 1 (other columns)
   oid_t tile_count = 2;
+
+  // Profile times
+  std::vector<double> update_default_partition_times_;
+  std::vector<double> transform_tg_times_;
+  oid_t tilegroup_transformed_;
 };
 
 }  // End brain namespace

--- a/src/include/brain/layout_tuner.h
+++ b/src/include/brain/layout_tuner.h
@@ -111,7 +111,7 @@ class LayoutTuner {
   // Profile times
   std::vector<double> update_default_partition_times_;
   std::vector<double> transform_tg_times_;
-  oid_t tilegroup_transformed_;
+  oid_t tile_groups_transformed_;
 };
 
 }  // End brain namespace

--- a/src/main/sdbench/sdbench_workload.cpp
+++ b/src/main/sdbench/sdbench_workload.cpp
@@ -109,7 +109,7 @@ std::vector<std::vector<oid_t>> predicate_distribution;
 
 // Bitmap for already used predicate
 #define MAX_PREDICATE_ATTR 10
-bool predicate_used[MAX_PREDICATE_ATTR] = {};
+bool predicate_used[MAX_PREDICATE_ATTR][MAX_PREDICATE_ATTR][MAX_PREDICATE_ATTR] = {};
 
 std::size_t predicate_distribution_size = 0;
 
@@ -423,14 +423,16 @@ static void ExecuteTest(std::vector<executor::AbstractExecutor *> &executors,
   // For holistic index
   if (state.holistic_indexing) {
     for (auto index_columns: index_columns_accessed) {
-      for (auto index_column : index_columns) {
-        oid_t index_column_oid = (oid_t)index_column;
-        if (!predicate_used[index_column_oid]) {
+      if (index_columns.size() == 3) { // It should be so for moderate query
+        oid_t i = oid_t(index_columns[0]);
+        oid_t j = oid_t(index_columns[1]);
+        oid_t k = oid_t(index_columns[2]);
+        if (!predicate_used[i][j][k]) {
           // Copy the predicate column
-          CopyColumn(index_column_oid);
-          CopyColumn(index_column_oid);
-          // CopyColumn(index_column_oid);
-          predicate_used[index_column_oid] = true;
+          CopyColumn(i);
+          CopyColumn(j);
+          CopyColumn(k);
+          predicate_used[i][j][k] = true;
         }
       }
     }


### PR DESCRIPTION
This PR 

* collects runtime processing time of index tuner and layout tuner, and prints them when the tuner gets deallocated.
* Fixed the problem of holistic index when new query arrives

```
00:11:49,651 [/data/rxian/peloton/src/brain/layout_tuner.cpp:41:~LayoutTuner] INFO  - 	[LAYOUT]	Total transform tilegroup time	4277.818221 ms
00:11:49,651 [/data/rxian/peloton/src/brain/layout_tuner.cpp:42:~LayoutTuner] INFO  - 	[LAYOUT]	Total tile group transformed	1607
00:11:49,651 [/data/rxian/peloton/src/brain/layout_tuner.cpp:43:~LayoutTuner] INFO  - 	[LAYOUT]	Average transform tilegroup time	2.661990 ms
00:11:49,651 [/data/rxian/peloton/src/brain/layout_tuner.cpp:44:~LayoutTuner] INFO  - 	[LAYOUT]	Total update partition time	388.813539 ms
00:11:49,656 [/data/rxian/peloton/src/brain/index_tuner.cpp:54:~IndexTuner] INFO  - 	[INDEX]	Total build index time 	6844.765508 ms
00:11:49,656 [/data/rxian/peloton/src/brain/index_tuner.cpp:55:~IndexTuner] INFO  - 	[INDEX]	Total tile groups indexed	1313
00:11:49,656 [/data/rxian/peloton/src/brain/index_tuner.cpp:56:~IndexTuner] INFO  - 	[INDEX]	Avg build index time 	5.213074 ms
00:11:49,656 [/data/rxian/peloton/src/brain/index_tuner.cpp:57:~IndexTuner] INFO  - 	[INDEX]	Total analyze index time 	1.976113 ms
00:11:49,656 [/data/rxian/peloton/src/brain/index_tuner.cpp:58:~IndexTuner] INFO  - 	[INDEX]	GetFrequentSamples() 	0.446609 ms	22.600378%
00:11:49,656 [/data/rxian/peloton/src/brain/index_tuner.cpp:59:~IndexTuner] INFO  - 	[INDEX]	ComputeWorkloadWriteRatio() 	0.474943 ms	24.034202%
00:11:49,656 [/data/rxian/peloton/src/brain/index_tuner.cpp:60:~IndexTuner] INFO  - 	[INDEX]	GetSuggestedIndices() 	0.029752 ms	1.505582%
00:11:49,656 [/data/rxian/peloton/src/brain/index_tuner.cpp:61:~IndexTuner] INFO  - 	[INDEX]	AddIndexes() 	0.605748 ms	30.653510%
00:11:49,656 [/data/rxian/peloton/src/brain/index_tuner.cpp:62:~IndexTuner] INFO  - 	[INDEX]	UpdateIndexUtility() 	0.419061 ms	21.206328%
```